### PR TITLE
기능: 카테고리 화면 구현

### DIFF
--- a/Projects/App/Sources/AppView/AppView.swift
+++ b/Projects/App/Sources/AppView/AppView.swift
@@ -23,7 +23,7 @@ struct AppView: View {
         store: .init(
           initialState: .init(),
           reducer: appCoordinatorReducer,
-          environment: .init()
+          environment: .init(userDefaultsService: .live)
         )
       )
       .onAppear { viewStore.send(.onAppear) }

--- a/Projects/Core/Common/Category/CategoryType.swift
+++ b/Projects/Core/Common/Category/CategoryType.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-public enum CategoryType: String {
-  case economic
-  case society
-  case politics
-  case science
-  case culture
-  case world
+public enum CategoryType: String, CaseIterable {
+  case politics = "정치"
+  case economic = "경제"
+  case society = "사회"
+  case culture = "생활/문화"
+  case world = "세계"
+  case science = "IT/과학"
 }

--- a/Projects/Core/Services/UserDefaults/UserDefaultsService.swift
+++ b/Projects/Core/Services/UserDefaults/UserDefaultsService.swift
@@ -1,0 +1,46 @@
+//
+//  UserDefaultsService.swift
+//  CoreKit
+//
+//  Created by GREEN on 2023/06/08.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import Combine
+import CombineExt
+import ComposableArchitecture
+import Foundation
+
+public struct UserDefaultsService {
+  public let save: (Bool) -> Effect<Void, Never>
+  public let load: () -> Effect<Bool, Never>
+  
+  private init(
+    save: @escaping (Bool) -> Effect<Void, Never>,
+    load: @escaping () -> Effect<Bool, Never>
+  ) {
+    self.save = save
+    self.load = load
+  }
+}
+
+public extension UserDefaultsService {
+  static var live = Self.init(
+    save: { value in
+      return Publishers.Create<Void, Never>(factory: { subscriber -> Cancellable in
+        subscriber.send(UserDefaults.standard.set(value, forKey: "registered"))
+        subscriber.send(completion: .finished)
+        return AnyCancellable({})
+      })
+      .eraseToEffect()
+    },
+    load: {
+      return Publishers.Create<Bool, Never>(factory: { subscriber -> Cancellable in
+        subscriber.send(UserDefaults.standard.bool(forKey: "registered"))
+        subscriber.send(completion: .finished)
+        return AnyCancellable({})
+      })
+      .eraseToEffect()
+    }
+  )
+}

--- a/Projects/DesignSystem/Sources/Views/Button/BottomButton.swift
+++ b/Projects/DesignSystem/Sources/Views/Button/BottomButton.swift
@@ -41,7 +41,8 @@ public struct BottomButton: View {
             Spacer()
           }
           .frame(height: 52)
-          .background(DesignSystem.Colors.blue200)
+          // TODO: - 추후 disabled에 대한 디자인 정의 시 변경될 예정
+          .background(disabled ? .gray : DesignSystem.Colors.blue200)
           .cornerRadius(12)
         }
       )

--- a/Projects/Features/Coordinator/AppCoordinator/AppCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/AppCoordinator/AppCoordinatorCore.swift
@@ -8,6 +8,7 @@
 
 import Combine
 import ComposableArchitecture
+import Services
 import Splash
 import TCACoordinators
 
@@ -25,7 +26,10 @@ public enum AppCoordinatorAction: IndexedRouterAction {
 }
 
 public struct AppCoordinatorEnvironment {
-  public init() {
+  var userDefaultsService: UserDefaultsService
+  
+  public init(userDefaultsService: UserDefaultsService) {
+    self.userDefaultsService = userDefaultsService
   }
 }
 
@@ -35,8 +39,8 @@ public let appCoordinatorReducer: Reducer<
   AppCoordinatorEnvironment
 > = appScreenReducer
   .forEachIndexedRoute(
-    environment: { _ in
-      AppScreenEnvironment()
+    environment: {
+      AppScreenEnvironment(userDefaultsService: $0.userDefaultsService)
     }
   )
   .withRouteReducer(
@@ -50,6 +54,25 @@ public let appCoordinatorReducer: Reducer<
           )
         ]
         return .none
+        
+      case .routeAction(_, action: .splash(._setCategoryViewLoad)):
+        state.routes = [
+          .root(
+            .setCategory(.init()),
+            embedInNavigationView: true
+          )
+        ]
+        return .none
+        
+      case .routeAction(_, action: .setCategory(._sendSelectedCategory)):
+        state.routes = [
+          .root(
+            .tabBar(.init(hotKeyword: .init(), main: .init(), myPage: .init())),
+            embedInNavigationView: true
+          )
+        ]
+        return .none
+        
       default: return .none
       }
     }

--- a/Projects/Features/Coordinator/AppCoordinator/AppScreenCore.swift
+++ b/Projects/Features/Coordinator/AppCoordinator/AppScreenCore.swift
@@ -10,6 +10,7 @@ import Combine
 import ComposableArchitecture
 import Foundation
 import NewsCardCoordinator
+import Services
 import SetCategory
 import SettingCoordinator
 import Splash
@@ -33,7 +34,10 @@ public enum AppScreenAction {
 }
 
 internal struct AppScreenEnvironment {
-  internal init() {
+  let userDefaultsService: UserDefaultsService
+  
+  internal init(userDefaultsService: UserDefaultsService) {
+    self.userDefaultsService = userDefaultsService
   }
 }
 
@@ -46,16 +50,16 @@ internal let appScreenReducer = Reducer<
     .pullback(
       state: /AppScreenState.splash,
       action: /AppScreenAction.splash,
-      environment: { _ in
-        SplashEnvironment()
+      environment: {
+        SplashEnvironment(userDefaultsService: $0.userDefaultsService)
       }
     ),
   setCategoryReducer
     .pullback(
       state: /AppScreenState.setCategory,
       action: /AppScreenAction.setCategory,
-      environment: { _ in
-        SetCategoryEnvironment()
+      environment: {
+        SetCategoryEnvironment(userDefaultsService: $0.userDefaultsService)
       }
     ),
   tabBarReducer

--- a/Projects/Features/Scene/SetCategoryScene/SetCategory/SetCategoryCore.swift
+++ b/Projects/Features/Scene/SetCategoryScene/SetCategory/SetCategoryCore.swift
@@ -7,31 +7,63 @@
 //
 
 import Combine
+import Common
 import ComposableArchitecture
 import Foundation
 
 public struct SetCategoryState: Equatable {
-  public init() { }
+  var allCategories: [String] = CategoryType.allCases.map {
+    $0.rawValue
+  }
+  var selectedCategories: [String]
+  var isAvailabledSelectButton: Bool {
+    !selectedCategories.isEmpty
+  }
+  
+  public init(selectedCategories: [String]) {
+    self.selectedCategories = selectedCategories
+  }
 }
 
 public enum SetCategoryAction: Equatable {
   // MARK: - User Action
+  case categoryTapped(String)
+  case selectButtonTapped
   
   // MARK: - Inner Business Action
+  case sendSelectedCategory
   
   // MARK: - Inner SetState Action
-  
-  // MARK: - Child Action
+  case setSelectedCategories([String])
 }
 
 public struct SetCategoryEnvironment {
+  // TODO: - 추후 회원가입 API 추가 필요
   public init() {}
 }
 
 public let setCategoryReducer = Reducer.combine([
   Reducer<SetCategoryState, SetCategoryAction, SetCategoryEnvironment> { state, action, env in
     switch action {
-    default: return .none
+    case let .categoryTapped(category):
+      if state.selectedCategories.contains(category) {
+        return Effect(value: .setSelectedCategories(state.selectedCategories.filter { $0 != category }))
+      } else {
+        state.selectedCategories.append(category)
+      }
+      return .none
+      
+    case .selectButtonTapped:
+      return Effect(value: .sendSelectedCategory)
+      
+    case .sendSelectedCategory:
+      // TODO: - 추후 선택된 카테고리에 대해 회원 정보를 담아 API 호출 연동 필요
+      // TODO: - 호출 응답 확인 후 상위 AppCoordinator에서 메인 화면으로 이동 로직 필요
+      return .none
+      
+    case let .setSelectedCategories(categories):
+      state.selectedCategories = categories
+      return .none
     }
   }
 ])

--- a/Projects/Features/Scene/SetCategoryScene/SetCategory/SetCategoryCore.swift
+++ b/Projects/Features/Scene/SetCategoryScene/SetCategory/SetCategoryCore.swift
@@ -17,7 +17,7 @@ public struct SetCategoryState: Equatable {
     $0.rawValue
   }
   var selectedCategories: [String]
-  var isAvailabledSelectButton: Bool {
+  var isSelectButtonEnabled: Bool {
     !selectedCategories.isEmpty
   }
   

--- a/Projects/Features/Scene/SetCategoryScene/SetCategory/SetCategoryView.swift
+++ b/Projects/Features/Scene/SetCategoryScene/SetCategory/SetCategoryView.swift
@@ -36,7 +36,7 @@ public struct SetCategoryView: View {
         
         BottomButton(
           title: "선택",
-          disabled: !viewStore.state.isAvailabledSelectButton,
+          disabled: !viewStore.state.isSelectButtonEnabled,
           action: { viewStore.send(.selectButtonTapped) }
         )
         .padding(.bottom, 8)

--- a/Projects/Features/Scene/SetCategoryScene/SetCategory/SetCategoryView.swift
+++ b/Projects/Features/Scene/SetCategoryScene/SetCategory/SetCategoryView.swift
@@ -7,6 +7,7 @@
 //
 
 import ComposableArchitecture
+import DesignSystem
 import SwiftUI
 
 public struct SetCategoryView: View {
@@ -18,8 +19,166 @@ public struct SetCategoryView: View {
   
   public var body: some View {
     WithViewStore(store) { viewStore in
-      Text("카테고리 설정 화면")
+      VStack(spacing: 0) {
+        TitleView()
+        
+        Spacer()
+          .frame(height: 64)
+        
+        ActiveCategoryGridView(store: store)
+        
+        Spacer()
+          .frame(height: 26)
+        
+        InActiveCategoryGridView()
+        
+        Spacer()
+        
+        BottomButton(
+          title: "선택",
+          disabled: !viewStore.state.isAvailabledSelectButton,
+          action: { viewStore.send(.selectButtonTapped) }
+        )
+        .padding(.bottom, 8)
+      }
     }
+    .shortsBackgroundView()
     .navigationBarHidden(true)
+  }
+}
+
+// MARK: - 타이틀 뷰
+private struct TitleView: View {
+  fileprivate var body: some View {
+    HStack {
+      Text("관심 키워드를 선택해주세요")
+        .font(.b20)
+        .foregroundColor(DesignSystem.Colors.grey100)
+      
+      Spacer()
+    }
+    .padding(.top, 32)
+    .padding(.horizontal, 24)
+  }
+}
+
+// MARK: - 활성화된 카테고리 그리드 뷰
+private struct ActiveCategoryGridView: View {
+  private let store: Store<SetCategoryState, SetCategoryAction>
+  private let columns = [
+    GridItem(.flexible()),
+    GridItem(.flexible()),
+    GridItem(.flexible())
+  ]
+
+  fileprivate init(store: Store<SetCategoryState, SetCategoryAction>) {
+    self.store = store
+  }
+
+  fileprivate var body: some View {
+    WithViewStore(store) { viewStore in
+      LazyVGrid(columns: columns, spacing: 16) {
+        ForEach(viewStore.state.allCategories, id: \.self) { category in
+          CategoryItemView(
+            store: store,
+            categoryName: category,
+            isSelected: viewStore.state.selectedCategories.contains(category)
+          )
+        }
+      }
+      .padding(.horizontal, 24)
+    }
+  }
+}
+
+// MARK: - 비활성화된 카테고리 그리드 뷰
+private struct InActiveCategoryGridView: View {
+  private let columns = [
+    GridItem(.flexible()),
+    GridItem(.flexible()),
+    GridItem(.flexible())
+  ]
+  private let title: [String?] = ["연예", "스포츠", nil]
+  
+  fileprivate var body: some View {
+    LazyVGrid(columns: columns, spacing: 16) {
+      ForEach(title, id: \.self) { title in
+        if let title = title {
+          VStack(spacing: 6) {
+            Text(title)
+              .font(.b14)
+              .foregroundColor(.black)
+            
+            Text("Coming soon!")
+              .font(.r12)
+          }
+          .frame(width: 98, height: 98)
+          .background(
+            Circle()
+              .fill(.white.opacity(0.3))
+          )
+        } else {
+          EmptyView()
+            .frame(width: 98, height: 98)
+        }
+      }
+    }
+    .padding(.horizontal, 24)
+  }
+}
+
+// MARK: - 카테고리 아이템 뷰
+private struct CategoryItemView: View {
+  private let store: Store<SetCategoryState, SetCategoryAction>
+  private var categoryName: String
+  @State private var isSelected: Bool
+  
+  fileprivate init(
+    store: Store<SetCategoryState, SetCategoryAction>,
+    categoryName: String,
+    isSelected: Bool
+  ) {
+    self.store = store
+    self.categoryName = categoryName
+    self.isSelected = isSelected
+  }
+  
+  fileprivate var body: some View {
+    WithViewStore(store) { viewStore in
+      Button(
+        action: {
+          isSelected.toggle()
+          viewStore.send(.categoryTapped(categoryName))
+        },
+        label: {
+          VStack(spacing: 8) {
+            Spacer()
+              .frame(height: 1)
+            
+            // TODO: - 추후 디자인이 나오면 해당 이미지로 변경 예정
+            Rectangle()
+              .fill(.gray)
+              .frame(width: 40, height: 40)
+            
+            Text(categoryName)
+              .font(.r14)
+              .foregroundColor(DesignSystem.Colors.grey90)
+          }
+          .frame(width: 98, height: 98)
+          // TODO: - 추후 선택/미선택에 대한 컬러값 확정 시 변경 예정
+          .background(
+            isSelected ?
+            Circle()
+              .fill(.green.opacity(0.64))
+            : Circle()
+              .fill(.white.opacity(0.64))
+          )
+          .overlay(
+            Circle()
+              .stroke(.white, lineWidth: 0.5)
+          )
+        }
+      )
+    }
   }
 }

--- a/Projects/Features/Scene/SplashScene/Splash/SplashCore.swift
+++ b/Projects/Features/Scene/SplashScene/Splash/SplashCore.swift
@@ -21,7 +21,8 @@ public enum SplashAction: Equatable {
   case viewDidLoad
   
   // MARK: - Inner Business Action
-  case _exitSplash
+  case _checkConnectHistory
+  case _setCategoryViewLoad
   
   // MARK: - Inner SetState Action
   
@@ -29,7 +30,11 @@ public enum SplashAction: Equatable {
 }
 
 public struct SplashEnvironment {
-  public init() {}
+  let userDefaultsService: UserDefaultsService
+  
+  public init(userDefaultsService: UserDefaultsService) {
+    self.userDefaultsService = userDefaultsService
+  }
 }
 
 public let splashReducer = Reducer.combine([
@@ -39,7 +44,17 @@ public let splashReducer = Reducer.combine([
       // TODO: - 추후 데이터 로드 되는 용도 (데이터 다 받아올 시 exitSplash 액션 방출)
       return .none
       
-    case ._exitSplash:
+    case ._checkConnectHistory:
+      return env.userDefaultsService.load()
+        .map({ status -> SplashAction in
+          if status {
+            return .viewDidLoad
+          } else {
+            return ._setCategoryViewLoad
+          }
+        })
+      
+    case ._setCategoryViewLoad:
       return .none
     }
   }

--- a/Projects/Features/Scene/SplashScene/Splash/SplashView.swift
+++ b/Projects/Features/Scene/SplashScene/Splash/SplashView.swift
@@ -22,7 +22,7 @@ public struct SplashView: View {
       // TODO: - 추후 로딩 화면 스플래쉬 이미지와 동일하게 변경 예정
       VStack {
         Button("스플래시") {
-          viewStore.send(.viewDidLoad)
+          viewStore.send(._checkConnectHistory)
         }
       }
       .shortsBackgroundView()


### PR DESCRIPTION
## Task

[카테고리 화면 구현](#23 )

## 참고
- 우선 디자인 세부적인것 적용전 카테고리 화면 구현 완료
- IDFV값은 추후 API 나오면 보낼 예정이며 그전 접속 이력 확인을 위해 UserDefaultsService 추가
- 스플래쉬 뷰에서 접속 이력을 확인하고 그에 따라 메인뷰 혹은 카테고리 설정뷰로 화면 전환 됩니다.
- 아래와 같이 카테고리 선택한 적이 없다면 (처음 접속 시) 스플래쉬 > 카테고리 > 메인 화면으로 전환되며 접속한 적이 있다면 스플래쉬 > 메인화면으로 전환됩니다.
- 서버 데이터를 받아오는 부분은 공통적으로 추후 API가 나오면 Main 뷰 onAppear 시 받으면 됩니다.
![Simulator Screen Recording - iPhone 14 Plus - 2023-06-08 at 19 02 03](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/72292617/bd009125-21eb-4e5a-8fe7-ac1c54269bec)
![Simulator Screen Recording - iPhone 14 Plus - 2023-06-08 at 19 02 21](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/72292617/db7fcff4-b454-4bae-9b9d-3158a149b4b3)
-> 잉 올리고보니 gif 두번째께 좀 이상한데 ㅋㅋ 스플래쉬 누르면 바로 메인 뷰 가는 gif입니다.
