### PR TITLE
기능: 웹 뷰 구현

### DIFF
--- a/Projects/DesignSystem/Sources/Views/Navigation/TopNavigationBar.swift
+++ b/Projects/DesignSystem/Sources/Views/Navigation/TopNavigationBar.swift
@@ -16,6 +16,7 @@ public struct TopNavigationBar: View {
   public let rightIcon: Image?
   public let rightText: String?
   public var rightIconButtonAction: () -> Void = {}
+  @Binding public var isAvailableRight: Bool
   
   public init(
     title: String? = nil,
@@ -24,7 +25,8 @@ public struct TopNavigationBar: View {
     leftIconButtonAction: @escaping () -> Void = {},
     rightIcon: Image? = nil,
     rightText: String? = nil,
-    rightIconButtonAction: @escaping () -> Void = {}
+    rightIconButtonAction: @escaping () -> Void = {},
+    isAvailableRight: Binding<Bool> = .constant(false)
   ) {
     self.title = title
     self.leftIcon = leftIcon
@@ -33,6 +35,7 @@ public struct TopNavigationBar: View {
     self.rightIcon = rightIcon
     self.rightText = rightText
     self.rightIconButtonAction = rightIconButtonAction
+    self._isAvailableRight = isAvailableRight
   }
   
   public var body: some View {
@@ -51,7 +54,8 @@ public struct TopNavigationBar: View {
           type: .right,
           icon: rightIcon,
           text: rightText,
-          action: rightIconButtonAction
+          action: rightIconButtonAction,
+          disabled: $isAvailableRight
         )
       }
       
@@ -77,6 +81,7 @@ fileprivate struct BarButton: View {
   private var icon: Image?
   private var text: String?
   private var action: () -> Void = {}
+  @Binding private var disabled: Bool
   
   fileprivate enum `Type` {
     case left
@@ -87,12 +92,14 @@ fileprivate struct BarButton: View {
     type: `Type` = .left,
     icon: Image? = nil,
     text: String? = nil,
-    action: @escaping () -> Void = {}
+    action: @escaping () -> Void = {},
+    disabled: Binding<Bool> = .constant(false)
   ) {
     self.type = type
     self.icon = icon
     self.text = text
     self.action = action
+    self._disabled = disabled
   }
   
   fileprivate var body: some View {
@@ -107,10 +114,11 @@ fileprivate struct BarButton: View {
         if let text = text {
           Text(text)
             .font(.r16)
-            .foregroundColor(DesignSystem.Colors.grey100)
+            .foregroundColor(disabled ? DesignSystem.Colors.grey40 : DesignSystem.Colors.grey100)
             .padding(type == .left ? .leading : .trailing, 16)
         }
       }
     }
+    .disabled(disabled)
   }
 }

--- a/Projects/DesignSystem/Sources/Views/Navigation/TopNavigationBar.swift
+++ b/Projects/DesignSystem/Sources/Views/Navigation/TopNavigationBar.swift
@@ -16,7 +16,7 @@ public struct TopNavigationBar: View {
   public let rightIcon: Image?
   public let rightText: String?
   public var rightIconButtonAction: () -> Void = {}
-  @Binding public var isAvailableRight: Bool
+  @Binding public var isRightButtonActive: Bool
   
   public init(
     title: String? = nil,
@@ -26,7 +26,7 @@ public struct TopNavigationBar: View {
     rightIcon: Image? = nil,
     rightText: String? = nil,
     rightIconButtonAction: @escaping () -> Void = {},
-    isAvailableRight: Binding<Bool> = .constant(false)
+    isRightButtonActive: Binding<Bool> = .constant(false)
   ) {
     self.title = title
     self.leftIcon = leftIcon
@@ -35,7 +35,7 @@ public struct TopNavigationBar: View {
     self.rightIcon = rightIcon
     self.rightText = rightText
     self.rightIconButtonAction = rightIconButtonAction
-    self._isAvailableRight = isAvailableRight
+    self._isRightButtonActive = isRightButtonActive
   }
   
   public var body: some View {
@@ -55,7 +55,7 @@ public struct TopNavigationBar: View {
           icon: rightIcon,
           text: rightText,
           action: rightIconButtonAction,
-          disabled: $isAvailableRight
+          disabled: $isRightButtonActive
         )
       }
       

--- a/Projects/DesignSystem/Sources/Views/ShortsWebView/ShortsWebView.swift
+++ b/Projects/DesignSystem/Sources/Views/ShortsWebView/ShortsWebView.swift
@@ -1,5 +1,5 @@
 //
-//  WebView.swift
+//  ShortsWebView.swift
 //  DesignSystem
 //
 //  Created by GREEN on 2023/04/28.
@@ -22,7 +22,7 @@ struct UIWebView: UIViewRepresentable {
   }
 }
 
-public struct WebView: View {
+public struct ShortsWebView: View {
   public let webAddress: String
   
   public init(webAddress: String) {

--- a/Projects/Features/Scene/Project.swift
+++ b/Projects/Features/Scene/Project.swift
@@ -133,5 +133,16 @@ let project = Project.make(
         .externalsrt("NukeUI"),
       ]
     ),
+    .make(
+      name: "Web",
+      product: .staticLibrary,
+      bundleId: "com.mashup.seeYouAgain.web.web",
+      sources: ["WebScene/Web/**"],
+      dependencies: [
+        .project(target: "CoreKit", path: .relativeToRoot("Projects/Core")),
+        .project(target: "DesignSystem", path: .relativeToRoot("Projects/DesignSystem")),
+        .externalsrt("TCA"),
+      ]
+    ),
   ]
 )

--- a/Projects/Features/Scene/WebScene/Web/WebCore.swift
+++ b/Projects/Features/Scene/WebScene/Web/WebCore.swift
@@ -1,0 +1,133 @@
+//
+//  WebCore.swift
+//  Web
+//
+//  Created by GREEN on 2023/06/21.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import Combine
+import Common
+import ComposableArchitecture
+import Foundation
+import Services
+
+public struct WebState: Equatable {
+  var webAddress: String
+  var saveButtonDisabled: Bool
+  var isDisplayTooltip: Bool
+  var saveToastMessage: String?
+  var warningToastMessage: String?
+  
+  public init(
+    webAddress: String,
+    saveButtonDisabled: Bool = false,
+    isDisplayTooltip: Bool = true
+  ) {
+    self.webAddress = webAddress
+    self.saveButtonDisabled = saveButtonDisabled
+    self.isDisplayTooltip = isDisplayTooltip
+  }
+}
+
+public enum WebAction: Equatable {
+  // MARK: - User Action
+  case backButtonTapped
+  case saveButtonTapped
+  case tooltipButtonTapped
+  
+  // MARK: - Inner Business Action
+  case _onAppear
+  case _presentSaveToast(String)
+  case _presentWaringToast(String)
+  case _hideSaveToast
+  case _hideWarningToast
+  
+  // MARK: - Inner SetState Action
+  case _setSaveButtonDisabled(Bool)
+  case _setIsDisplayTooltip(Bool)
+  case _setSaveToastMessage(String?)
+  case _setWarningToastMessage(String?)
+}
+
+public struct WebEnvironment {
+  let mainQueue: AnySchedulerOf<DispatchQueue>
+  
+  public init(mainQueue: AnySchedulerOf<DispatchQueue> = .main) {
+    self.mainQueue = mainQueue
+  }
+}
+
+public let webReducer = Reducer.combine([
+  Reducer<WebState, WebAction, WebEnvironment> { state, action, env in
+    struct WebSaveToastCancelID: Hashable {}
+    struct WebWarningToastCancelID: Hashable {}
+    
+    switch action {
+    case ._onAppear:
+      return .merge([
+        Effect(value: ._setIsDisplayTooltip(false))
+          .delay(for: 4, scheduler: env.mainQueue)
+          .eraseToEffect(),
+        // TODO: - 추후 해당 뉴스가 이미 저장된 뉴스인지 API 판별 후 저장 버튼 비활성화 처리 추가 필요
+      ])
+      
+    case .backButtonTapped:
+      return .none
+      
+    case .saveButtonTapped:
+      // TODO: - 추후 뉴스 저장 API 구현
+      // TODO: - 뉴스 저장에 따른 리스폰스를 통해 토스트 메시지 노출 (저장완료 or 에러)
+      // TODO: - 저장 버튼 상태값 변경
+      return Effect(value: ._setSaveButtonDisabled(true))
+      
+    case .tooltipButtonTapped:
+      return Effect(value: ._setIsDisplayTooltip(false))
+      
+    case let ._presentSaveToast(toastMessage):
+      return .concatenate([
+        Effect(value: ._setSaveToastMessage(toastMessage)),
+        .cancel(id: WebSaveToastCancelID()),
+        Effect(value: ._hideSaveToast)
+          .delay(for: 2, scheduler: env.mainQueue)
+          .eraseToEffect()
+          .cancellable(id: WebSaveToastCancelID(), cancelInFlight: true)
+      ])
+      
+    case let ._presentWaringToast(toastMessage):
+      return .concatenate([
+        Effect(value: ._setWarningToastMessage(toastMessage)),
+        .cancel(id: WebWarningToastCancelID()),
+        Effect(value: ._hideWarningToast)
+          .delay(for: 2, scheduler: env.mainQueue)
+          .eraseToEffect()
+          .cancellable(id: WebWarningToastCancelID(), cancelInFlight: true)
+      ])
+      
+    case ._hideSaveToast:
+      return Effect(value: ._setSaveToastMessage(nil))
+      
+    case ._hideWarningToast:
+      return Effect(value: ._setWarningToastMessage(nil))
+      
+    case let ._setSaveButtonDisabled(disabled):
+      state.saveButtonDisabled = disabled
+      return .none
+      
+    case let ._setIsDisplayTooltip(isDisplay):
+      if state.isDisplayTooltip == isDisplay {
+        return .none
+      }
+      state.isDisplayTooltip = isDisplay
+      return .none
+    
+    case let ._setSaveToastMessage(toastMessage):
+      state.saveToastMessage = toastMessage
+      return .none
+      
+    case let ._setWarningToastMessage(toastMessage):
+      state.warningToastMessage = toastMessage
+      return .none
+    }
+  }
+])

--- a/Projects/Features/Scene/WebScene/Web/WebView.swift
+++ b/Projects/Features/Scene/WebScene/Web/WebView.swift
@@ -27,7 +27,7 @@ public struct WebView: View {
             leftIconButtonAction: { viewStore.send(.backButtonTapped) },
             rightText: "저장",
             rightIconButtonAction: { viewStore.send(.saveButtonTapped) },
-            isAvailableRight: viewStore.binding(
+            isRightButtonActive: viewStore.binding(
               get: \.saveButtonDisabled,
               send: { WebAction._setSaveButtonDisabled($0) }
             )

--- a/Projects/Features/Scene/WebScene/Web/WebView.swift
+++ b/Projects/Features/Scene/WebScene/Web/WebView.swift
@@ -1,0 +1,142 @@
+//
+//  WebView.swift
+//  Web
+//
+//  Created by GREEN on 2023/06/21.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import Common
+import ComposableArchitecture
+import DesignSystem
+import SwiftUI
+
+public struct WebView: View {
+  private let store: Store<WebState, WebAction>
+  
+  public init(store: Store<WebState, WebAction>) {
+    self.store = store
+  }
+  
+  public var body: some View {
+    WithViewStore(store) { viewStore in
+      ZStack {
+        VStack {
+          TopNavigationBar(
+            leftIcon: DesignSystem.Icons.iconNavigationLeft,
+            leftIconButtonAction: { viewStore.send(.backButtonTapped) },
+            rightText: "저장",
+            rightIconButtonAction: { viewStore.send(.saveButtonTapped) },
+            isAvailableRight: viewStore.binding(
+              get: \.saveButtonDisabled,
+              send: { WebAction._setSaveButtonDisabled($0) }
+            )
+          )
+          
+          ShortsWebView(webAddress: viewStore.state.webAddress)
+        }
+        .apply(content: { view in
+          WithViewStore(store.scope(state: \.saveToastMessage)) { saveToastMessageViewStore in
+            view.toast(
+              text: saveToastMessageViewStore.state,
+              toastType: .info
+            )
+          }
+        })
+        .apply(content: { view in
+          WithViewStore(store.scope(state: \.warningToastMessage)) { warningToastMessageViewStore in
+            view.toast(
+              text: warningToastMessageViewStore.state,
+              toastType: .warning
+            )
+          }
+        })
+        
+        if viewStore.state.isDisplayTooltip {
+          TooltipView(store: store)
+            .padding(.top, 33)
+            .padding(.trailing, 4)
+        }
+      }
+      .onAppear { viewStore.send(._onAppear) }
+    }
+    .navigationBarHidden(true)
+  }
+}
+
+// MARK: - Tooltip View
+private struct TooltipView: View {
+  private let store: Store<WebState, WebAction>
+  
+  fileprivate init(store: Store<WebState, WebAction>) {
+    self.store = store
+  }
+  
+  fileprivate var body: some View {
+    WithViewStore(store) { viewStore in
+      VStack {
+        HStack {
+          Spacer()
+          
+          TooltipShape()
+            .onTapGesture {
+              viewStore.send(.tooltipButtonTapped)
+            }
+        }
+        Spacer()
+      }
+    }
+  }
+}
+
+// MARK: - Tooltip Shape
+private struct TooltipShape: View {
+  fileprivate var body: some View {
+    ZStack {
+      CustomTriangleShape()
+        .fill(DesignSystem.Colors.blue200)
+        .padding(.leading, 178)
+      
+      CustomRectangleShape()
+    }
+    .frame(width: 216, height: 45)
+  }
+}
+
+// MARK: - Custom Rectangle Shape
+private struct CustomRectangleShape: View {
+  fileprivate var body: some View {
+    VStack {
+      Spacer()
+      
+      Text("오래 간직할 뉴스에 추가해보세요!")
+        .font(.r14)
+        .foregroundColor(DesignSystem.Colors.white)
+        .padding(.vertical, 8)
+        .padding(.horizontal, 16)
+        .background(RoundedRectangle(cornerRadius: 20).fill(DesignSystem.Colors.blue200))
+    }
+  }
+}
+
+// MARK: - Custom Triangle Shape
+private struct CustomTriangleShape: Shape {
+  fileprivate func path(in rect: CGRect) -> Path {
+    var path = Path()
+    let width: CGFloat = 24
+    let height: CGFloat = 24
+    let radius: CGFloat = 1
+    
+    path.move(to: CGPoint(x: rect.minX + width / 2 - radius, y: rect.minY))
+    path.addQuadCurve(
+      to: CGPoint(x: rect.minX + width / 2 + radius, y: rect.minY),
+      control: CGPoint(x: rect.minX + width / 2, y: rect.minY + radius)
+    )
+    path.addLine(to: CGPoint(x: rect.minX + width, y: rect.minY + height))
+    path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + height))
+    
+    path.closeSubpath()
+    
+    return path
+  }
+}


### PR DESCRIPTION
## Task
[웹 뷰 구현](#55 )

## 참고
- 공통적으로 사용될 웹 뷰를 구현하였습니다.
  - Web 모듈로 Scene으로 속하며 View/Core를 두어 뷰 및 동작 사양을 구현하였습니다.
  - 사용하실때 필요한 모듈에서 해당 Scene을 project 파일에서 설정 후 임포트하여 사용하면 됩니다.
  - 해당 뷰를 호출 시 뉴스 주소 (String) 값만 넘겨주시면 됩니다.
  - onAppear 시 해당 뉴스가 이미 저장된 뉴스인지 체크하는 API 등 필요하신 부분 채워서 사용하시면 됩니다! (TODO 주석으로 표기해놨음)
  - 그 외 토스트 노출등도 폼을 만들어두어서 필요하신 API 붙이실때 리팩하면 됩니다!
- 아래는 예시 동작 사양을 나타내며 해당 샘플 코드는 제거하고 PR 올렸으며 팔로업이 필요하시면 요청 부탁드립니다🙏🏻
![Simulator Screen Recording - iPhone 14 Pro - 2023-06-21 at 15 48 23](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/72292617/fbb9c8ce-64eb-433e-b1a1-094324335d4e)



