### PR TITLE
기능: 로딩 인디케이터 구현

### DIFF
--- a/Projects/App/Sources/Lifecycle/AppDelegate.swift
+++ b/Projects/App/Sources/Lifecycle/AppDelegate.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
 //
 
+import DesignSystem
 import Foundation
 import SwiftUI
 import UIKit
@@ -29,7 +30,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     window?.rootViewController = UIHostingController(rootView: appView)
     window?.makeKeyAndVisible()
+    setupLoadingWindow()
     
     return true
+  }
+  
+  func setupLoadingWindow() {
+    _ = LoadingWindow.shared
   }
 }

--- a/Projects/DesignSystem/Sources/Views/Loading/LoadingView.swift
+++ b/Projects/DesignSystem/Sources/Views/Loading/LoadingView.swift
@@ -1,0 +1,20 @@
+//
+//  LoadingView.swift
+//  DesignSystem
+//
+//  Created by GREEN on 2023/06/23.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import SwiftUI
+
+public struct LoadingView: View {
+  public var body: some View {
+    VStack(spacing: 5) {
+      ProgressView()
+        .scaleEffect(2.0)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(DesignSystem.Colors.grey100.opacity(0.4))
+  }
+}

--- a/Projects/DesignSystem/Sources/Views/Loading/LoadingWindow.swift
+++ b/Projects/DesignSystem/Sources/Views/Loading/LoadingWindow.swift
@@ -1,0 +1,55 @@
+//
+//  LoadingWindow.swift
+//  DesignSystem
+//
+//  Created by GREEN on 2023/06/23.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import SwiftUI
+import UIKit
+
+public class LoadingWindow: UIWindow {
+  public static let shared = LoadingWindow(frame: UIScreen.main.bounds)
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented: please use LoadingWindow.shared")
+  }
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    let loadingViewController = UIHostingController(rootView: LoadingView())
+    loadingViewController.view?.backgroundColor = .clear
+    self.rootViewController = loadingViewController
+    self.isHidden = true
+  }
+
+  func show() {
+    self.isHidden = false
+  }
+
+  func hide() {
+    self.isHidden = true
+  }
+
+  func toggle() {
+    if self.isHidden {
+      show()
+    } else {
+      hide()
+    }
+  }
+}
+
+public extension View {
+  func loading(
+    _ isLoading: Bool
+  ) -> Self {
+    if isLoading {
+      LoadingWindow.shared.show()
+    } else {
+      LoadingWindow.shared.hide()
+    }
+    return self
+  }
+}

--- a/Projects/DesignSystem/Sources/Views/Loading/LoadingWindow.swift
+++ b/Projects/DesignSystem/Sources/Views/Loading/LoadingWindow.swift
@@ -42,9 +42,7 @@ public class LoadingWindow: UIWindow {
 }
 
 public extension View {
-  func loading(
-    _ isLoading: Bool
-  ) -> Self {
+  func loading(_ isLoading: Bool) -> Self {
     if isLoading {
       LoadingWindow.shared.show()
     } else {


### PR DESCRIPTION
### Task
공통 로딩 인디케이터 구현(#60)

### 참고
- 우선 시스템 제공 인디케이터를 사용해 로딩 인디케이터 구현하였습니다.
- 최상단 뷰에 종속시키더라도 하단 코어에서부터 액션을 받아 최상단까지 풀백 받는 지금 토스트같은 구현이 코드 상 많은 부분을 차지하기에 window를 건드려서 어디서라도 간단히 최상단으로 노출되도록 구현되었습니다.
- 사용은 아주 단순히 요렇게 하시면 됩니다.
  - 로딩 인디케이터가 필요한 뷰의 State에 isLoading 프로퍼티 추가
  - 해당 뷰에서 `.loading(viewStore.state.isLoading)` 모디파이어를 붙이면 끝!
  - 해당 인디케이터를 노출 시키는 시점은 아마도 데이터를 요청할때 진행되고 통신이 정상적으로 다 끝나면 액션에서 해당 isLoading 프로퍼티의 값을 변경하시면 됩니다.
  
### 동작 예시

https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/72292617/3103def1-ee97-43d0-b595-3b789dd99d8c

