### PR TITLE
리팩터: 스플래쉬 후 이동 로직 변경

### DIFF
--- a/Projects/Features/Coordinator/AppCoordinator/AppCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/AppCoordinator/AppCoordinatorCore.swift
@@ -63,7 +63,7 @@ public let appCoordinatorReducer: Reducer<
   .withRouteReducer(
     Reducer { state, action, env in
       switch action {
-      case .routeAction(_, action: .splash(.viewDidLoad)):
+      case .routeAction(_, action: .splash(._moveToHome)):
         state.routes = [
           .root(
             .tabBar(
@@ -80,7 +80,7 @@ public let appCoordinatorReducer: Reducer<
         ]
         return .none
         
-      case .routeAction(_, action: .splash(._setCategoryViewLoad)):
+      case .routeAction(_, action: .splash(._moveToSetCategory)):
         state.routes = [
           .root(
             .setCategory(.init()),

--- a/Projects/Features/Scene/SetCategoryScene/SetCategory/SetCategoryCore.swift
+++ b/Projects/Features/Scene/SetCategoryScene/SetCategory/SetCategoryCore.swift
@@ -43,7 +43,6 @@ public enum SetCategoryAction: Equatable {
 }
 
 public struct SetCategoryEnvironment {
-  // TODO: - 추후 회원가입 API 추가 필요
   let mainQueue: AnySchedulerOf<DispatchQueue>
   let userDefaultsService: UserDefaultsService
   let categoryService: CategoryService
@@ -102,7 +101,6 @@ public let setCategoryReducer = Reducer.combine([
         Effect(value: ._setToastMessage(toastMessage)),
         .cancel(id: SetCategoryToastCancelID()),
         Effect(value: ._hideToast)
-          // MARK: - 추후 토스트 지속 시간 가이드에 따라 변경 예정
           .delay(for: 2, scheduler: env.mainQueue)
           .eraseToEffect()
           .cancellable(id: SetCategoryToastCancelID(), cancelInFlight: true)

--- a/Projects/Features/Scene/SplashScene/Splash/SplashCore.swift
+++ b/Projects/Features/Scene/SplashScene/Splash/SplashCore.swift
@@ -17,24 +17,15 @@ public struct SplashState: Equatable {
 }
 
 public enum SplashAction: Equatable {
-  // MARK: - User Action
-  case viewDidLoad
-  
   // MARK: - Inner Business Action
+  case _onAppear
   case _checkConnectHistory
-  case _setCategoryViewLoad
-  
-  // MARK: - Inner SetState Action
-  
-  // MARK: - Child Action
-  
-  // MARK: - API 호출 예시로 이후 PR에서 제거 예정
-  case testCategory
+  case _moveToHome
+  case _moveToSetCategory
 }
 
 public struct SplashEnvironment {
   let userDefaultsService: UserDefaultsService
-  let categoryService: CategoryService = .live
   
   public init(userDefaultsService: UserDefaultsService) {
     self.userDefaultsService = userDefaultsService
@@ -44,41 +35,24 @@ public struct SplashEnvironment {
 public let splashReducer = Reducer.combine([
   Reducer<SplashState, SplashAction, SplashEnvironment> { state, action, env in
     switch action {
-    case .viewDidLoad:
-      // TODO: - 추후 데이터 로드 되는 용도 (데이터 다 받아올 시 exitSplash 액션 방출)
-      return .none
+    case ._onAppear:
+      return Effect(value: ._checkConnectHistory)
       
     case ._checkConnectHistory:
       return env.userDefaultsService.load()
         .map({ status -> SplashAction in
           if status {
-            return .viewDidLoad
+            return ._moveToHome
           } else {
-            return ._setCategoryViewLoad
+            return ._moveToSetCategory
           }
         })
       
-    case ._setCategoryViewLoad:
+    case ._moveToHome:
       return .none
       
-    // MARK: - 테스트용 액션으로 추후 PR에서 제거 예정
-    case .testCategory:
-      return env.categoryService.saveCategory(["POLITICS"])
-        .catchToEffect()
-        .flatMapLatest { result -> Effect<SplashAction, Never> in
-          switch result {
-          case let .success(categories):
-            return .none
-            
-          case let .failure(error):
-            if let error = error.toProviderError() {
-              return .none
-            } else {
-              return .none
-            }
-          }
-        }
-        .eraseToEffect()
+    case ._moveToSetCategory:
+      return .none
     }
   }
 ])

--- a/Projects/Features/Scene/SplashScene/Splash/SplashView.swift
+++ b/Projects/Features/Scene/SplashScene/Splash/SplashView.swift
@@ -19,13 +19,13 @@ public struct SplashView: View {
   
   public var body: some View {
     WithViewStore(store) { viewStore in
-      // TODO: - 추후 로딩 화면 스플래쉬 이미지와 동일하게 변경 예정
       VStack {
-        Button("스플래시") {
-          viewStore.send(._checkConnectHistory)
-        }
+        // TODO: - 추후 로딩 화면 스플래쉬 이미지와 동일하게 변경 예정
+        Text("로고")
       }
-      .shortsBackgroundView()
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .background(DesignSystem.Colors.lightBlue)
+      .onAppear { viewStore.send(._onAppear) }
     }
     .navigationBarHidden(true)
   }


### PR DESCRIPTION
## Task
[스플래쉬 이동 로직 관련 변경](#63 )

## 참고
- 테스트용 버튼을 두어 이동 처리한 스플래쉬 로직을 실제 기획에 맞게 변경
- 스플래쉬 뷰 변경 (로고는 추후 삽입 예정)
- 반영 완료된 코드에 대한 TODO 주석 제거

