### PR TITLE
기능: 오래 간직할 숏스 화면 구현

### DIFF
--- a/Projects/Features/Coordinator/LongStorageCoordinator/LongStorageCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/LongStorageCoordinator/LongStorageCoordinatorCore.swift
@@ -18,7 +18,13 @@ public struct LongStorageCoordinatorState: Equatable, IndexedRouterState {
   public init(
     routes: [Route<LongStorageScreenState>] = [
       .root(
-        .longStorageNewsList(.init()),
+        .longStorageNewsList(
+          .init(
+            isInEditMode: false,
+            shortslistCount: 6,
+            shortsClearCount: 3
+          )
+        ),
         embedInNavigationView: true
       )
     ]
@@ -47,6 +53,28 @@ public let longStorageCoordinatorReducer: Reducer<
   .withRouteReducer(
     Reducer { state, action, env in
       switch action {
+      case .routeAction(
+        _,
+        action: .longStorageNewsList(
+          .shortsNewsItem(
+            id: _,
+            action: .cardAction(
+              .rightButtonTapped
+            )
+          )
+        )
+      ):
+        state.routes.push(.web(.init(webAddress: "https://naver.com")))
+        return .none
+        
+      case .routeAction(_, action: .longStorageNewsList(.shortsNewsItem(id: _, action: .cardAction(.cardTapped)))):
+        state.routes.push(.web(.init(webAddress: "https://naver.com")))
+        return .none
+
+      case .routeAction(_, action: .web(.backButtonTapped)):
+        state.routes.pop()
+        return .none
+        
       default: return .none
       }
     }

--- a/Projects/Features/Coordinator/LongStorageCoordinator/LongStorageCoordinatorView.swift
+++ b/Projects/Features/Coordinator/LongStorageCoordinator/LongStorageCoordinatorView.swift
@@ -10,6 +10,7 @@ import ComposableArchitecture
 import LongStorageNewsList
 import SwiftUI
 import TCACoordinators
+import Web
 
 public struct LongStorageCoordinatorView: View {
   private let store: Store<LongStorageCoordinatorState, LongStorageCoordinatorAction>
@@ -25,6 +26,11 @@ public struct LongStorageCoordinatorView: View {
           state: /LongStorageScreenState.longStorageNewsList,
           action: LongStorageScreenAction.longStorageNewsList,
           then: LongStorageNewsListView.init
+        )
+        CaseLet(
+          state: /LongStorageScreenState.web,
+          action: LongStorageScreenAction.web,
+          then: WebView.init
         )
       }
     }

--- a/Projects/Features/Coordinator/LongStorageCoordinator/LongStorageScreenCore.swift
+++ b/Projects/Features/Coordinator/LongStorageCoordinator/LongStorageScreenCore.swift
@@ -10,13 +10,16 @@ import ComposableArchitecture
 import LongStorageNewsList
 import Services
 import TCACoordinators
+import Web
 
 public enum LongStorageScreenState: Equatable {
   case longStorageNewsList(LongStorageNewsListState)
+  case web(WebState)
 }
 
 public enum LongStorageScreenAction: Equatable {
   case longStorageNewsList(LongStorageNewsListAction)
+  case web(WebAction)
 }
 
 internal struct LongStorageScreenEnvironment {
@@ -27,6 +30,14 @@ internal let longStorageScreenReducer = Reducer<
   LongStorageScreenAction,
   LongStorageScreenEnvironment
 >.combine([
+  webReducer
+    .pullback(
+      state: /LongStorageScreenState.web,
+      action: /LongStorageScreenAction.web,
+      environment: { _ in
+        WebEnvironment()
+      }
+    ),
   longStorageNewsListReducer
     .pullback(
       state: /LongStorageScreenState.longStorageNewsList,
@@ -34,5 +45,5 @@ internal let longStorageScreenReducer = Reducer<
       environment: { _ in
         LongStorageNewsListEnvironment()
       }
-    ),
+    )
 ])

--- a/Projects/Features/Coordinator/Project.swift
+++ b/Projects/Features/Coordinator/Project.swift
@@ -48,6 +48,7 @@ let project = Project.make(
       sources: ["LongStorageCoordinator/**"],
       dependencies: [
         .project(target: "LongStorageNewsList", path: .relativeToRoot("Projects/Features/Scene")),
+        .project(target: "Web", path: .relativeToRoot("Projects/Features/Scene")),
         .externalsrt("TCA"),
         .externalsrt("TCACoordinators"),
       ]

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongShortsItem/LongShortsCardCore.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongShortsItem/LongShortsCardCore.swift
@@ -1,0 +1,87 @@
+//
+//  LongShortsCardCore.swift
+//  LongStorageNewsList
+//
+//  Created by 안상희 on 2023/06/25.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import ComposableArchitecture
+import Web
+
+public struct News: Equatable, Identifiable {
+  public let id: Int
+  let title: String
+  let thumbnailImageUrl: String?
+  let newsLink: String
+  let press: String
+  let writtenDateTime: String
+  let type: String
+  
+  public init(
+    id: Int,
+    title: String,
+    thumbnailImageUrl: String?,
+    newsLink: String,
+    press: String,
+    writtenDateTime: String,
+    type: String
+  ) {
+    self.id = id
+    self.title = title
+    self.thumbnailImageUrl = thumbnailImageUrl
+    self.newsLink = newsLink
+    self.press = press
+    self.writtenDateTime = writtenDateTime
+    self.type = type
+  }
+}
+
+public struct LongShortsCardState: Equatable, Identifiable {
+  public var id: Int
+  var news: News
+  var isCardSelectable: Bool
+  var isSelected: Bool
+  
+  public init(
+    id: Int,
+    news: News,
+    isCardSelectable: Bool,
+    isSelected: Bool
+  ) {
+    self.id = id
+    self.news = news
+    self.isCardSelectable = isCardSelectable
+    self.isSelected = isSelected
+  }
+  
+  var web: WebState = WebState(webAddress: "https://naver.com")
+}
+
+public enum LongShortsCardAction: Equatable {
+  // MARK: - User Action
+  case rightButtonTapped
+  case cardTapped
+  
+  // MARK: - Inner Business Action
+  
+  // MARK: - Inner SetState Action
+  
+  // MARK: - Child Action
+}
+
+public struct LongShortsCardEnvironment {
+  public init() {}
+}
+
+public let longShortsCardReducer = Reducer<
+  LongShortsCardState,
+  LongShortsCardAction,
+  LongShortsCardEnvironment
+>.combine([
+  Reducer { state, action, env in
+    switch action {
+    default: return .none
+    }
+  }
+])

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongShortsItem/LongShortsCardView.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongShortsItem/LongShortsCardView.swift
@@ -1,0 +1,115 @@
+//
+//  LongShortsCardView.swift
+//  LongStorageNewsList
+//
+//  Created by 안상희 on 2023/06/25.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import ComposableArchitecture
+import DesignSystem
+import NukeUI
+import SwiftUI
+
+struct LongShortsCardView: View {
+  private let store: Store<LongShortsCardState, LongShortsCardAction>
+  
+  init(store: Store<LongShortsCardState, LongShortsCardAction>) {
+    self.store = store
+  }
+  
+  var body: some View {
+    WithViewStore(store) { viewStore in
+      HStack(alignment: .top, spacing: 0) {
+        if let imageUrl = viewStore.state.news.thumbnailImageUrl {
+          // TODO: 서버에서 받아오는 URL 이미지로 변경 필요
+          LazyImage(url: URL(string: imageUrl)) { state in
+            if let image = state.image {
+              image
+                .resizable()
+                .frame(width: 56, height: 56)
+                .clipShape(Circle())
+            } else {
+              ProgressView()
+            }
+          }
+          
+          Spacer()
+            .frame(width: 16)
+        }
+        
+        NewsDataView(news: viewStore.state.news)
+        
+        if viewStore.isCardSelectable {
+          Button {
+            viewStore.send(.rightButtonTapped)
+          } label: {
+            DesignSystem.Icons.iconChevronRight
+              .frame(width: 16, height: 16)
+          }
+        }
+      }
+      .frame(maxWidth: .infinity)
+      .padding(20)
+      .background(DesignSystem.Colors.grey20)
+      .cornerRadius(16)
+      .onTapGesture {
+        if viewStore.isCardSelectable {
+          viewStore.send(.cardTapped)
+        }
+      }
+    }
+  }
+}
+
+private struct NewsDataView: View {
+  private let news: News
+  
+  fileprivate init(news: News) {
+    self.news = news
+  }
+  
+  fileprivate var body: some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 0) {
+        Text(news.title)
+          .font(.b16)
+          .foregroundColor(DesignSystem.Colors.grey90)
+          .lineLimit(2)
+        
+        Spacer()
+      }
+      
+      Spacer()
+        .frame(height: 10)
+      
+      HStack(spacing: 4) {
+        Text(news.press)
+          .font(.r14)
+          .foregroundColor(DesignSystem.Colors.grey50)
+        
+        // TODO: 카테고리 타입에 맞도록 수정 필요
+        CategoryView(
+          category: "경제",
+          color: DesignSystem.Colors.economic
+        )
+        
+        Spacer()
+      }
+      
+      Spacer()
+        .frame(height: 4)
+      
+      HStack(spacing: 4) {
+        DesignSystem.Icons.iconCalendar
+          .frame(width: 14, height: 14)
+        
+        Text(news.writtenDateTime)
+          .font(.r13)
+          .foregroundColor(DesignSystem.Colors.grey60)
+        
+        Spacer()
+      }
+    }
+  }
+}

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongShortsItem/LongShortsItemCore.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongShortsItem/LongShortsItemCore.swift
@@ -1,0 +1,70 @@
+//
+//  LongShortsItemCore.swift
+//  LongStorageNewsList
+//
+//  Created by 안상희 on 2023/06/25.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import ComposableArchitecture
+
+public struct LongShortsItemState: Equatable, Identifiable {
+  public var id: Int
+  var isInEditMode: Bool
+  var isSelected: Bool
+  var cardState: LongShortsCardState
+  
+  public init(
+    id: Int,
+    isInEditMode: Bool,
+    isSelected: Bool,
+    cardState: LongShortsCardState
+  ) {
+    self.id = id
+    self.isInEditMode = isInEditMode
+    self.isSelected = isSelected
+    self.cardState = cardState
+  }
+}
+
+public enum LongShortsItemAction: Equatable {
+  // MARK: - User Action
+  case itemSelected // 체크마크 선택
+  case itemTapped // 뉴스 카드 선택
+  
+  // MARK: - Inner Business Action
+  case _shortsItemSelectionChanged
+  
+  // MARK: - Inner SetState Action
+  
+  // MARK: - Child Action
+  case cardAction(LongShortsCardAction)
+}
+
+public struct LongShortsItemEnvironment {
+  public init() {}
+}
+
+public let longShortsItemReducer = Reducer<
+  LongShortsItemState,
+  LongShortsItemAction,
+  LongShortsItemEnvironment
+>.combine([
+  longShortsCardReducer
+    .pullback(
+      state: \LongShortsItemState.cardState,
+      action: /LongShortsItemAction.cardAction,
+      environment: { _ in
+        LongShortsCardEnvironment()
+      }
+    ),
+  Reducer { state, action, env in
+    switch action {
+    case ._shortsItemSelectionChanged:
+      state.isSelected.toggle()
+      return .none
+      
+    default: return .none
+    }
+  }
+])

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongShortsItem/LongShortsItemView.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongShortsItem/LongShortsItemView.swift
@@ -1,0 +1,42 @@
+//
+//  LongShortsItemView.swift
+//  LongStorageNewsList
+//
+//  Created by 안상희 on 2023/06/25.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import ComposableArchitecture
+import DesignSystem
+import SwiftUI
+
+struct LongShortsItemView: View {
+  private let store: Store<LongShortsItemState, LongShortsItemAction>
+  
+  init(store: Store<LongShortsItemState, LongShortsItemAction>) {
+    self.store = store
+  }
+  
+  var body: some View {
+    WithViewStore(store) { viewStore in
+      HStack(spacing: 0) {
+        if viewStore.state.isInEditMode {
+          Toggle("", isOn: viewStore.binding(get: \.isSelected, send: ._shortsItemSelectionChanged))
+            .labelsHidden()
+            .toggleStyle(ShortsToggleStyle())
+            .frame(width: 24, height: 24)
+          
+          Spacer()
+            .frame(width: 16)
+        }
+        
+        LongShortsCardView(
+          store: store.scope(
+            state: \LongShortsItemState.cardState,
+            action: LongShortsItemAction.cardAction
+          )
+        )
+      }
+    }
+  }
+}

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageNewsListCore.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageNewsListCore.swift
@@ -10,33 +10,126 @@ import Combine
 import ComposableArchitecture
 import Foundation
 
+
 public struct LongStorageNewsListState: Equatable {
-  public init() { }
+  var isInEditMode: Bool
+  var month: String
+  var shortsNewsItemsCount: Int // 저장한 숏스 수
+  var shortsCompleteCount: Int // 완료한 숏스 수
+  var shortsNewsItems: IdentifiedArrayOf<LongShortsItemState> = []
+  var isLatestMode: Bool = true
+  
+  public init(
+    isInEditMode: Bool,
+    shortslistCount: Int,
+    shortsClearCount: Int
+  ) {
+    self.isInEditMode = isInEditMode
+    self.month = Date().yearMonthToString()
+    self.shortsNewsItemsCount = shortslistCount
+    self.shortsCompleteCount = shortsClearCount
+  }
 }
 
 public enum LongStorageNewsListAction: Equatable {
   // MARK: - User Action
   case backButtonTapped
+  case editButtonTapped
+  case deleteButtonTapped
+  case datePickerTapped
+  case previousMonthButtonTapped
+  case nextMonthButtonTapped
+  case sortByTimeButtonTapped
+  case sortByTypeButtonTapped
   
   // MARK: - Inner Business Action
+  case _onAppear
   
   // MARK: - Inner SetState Action
+  case _setEditMode
+  case _setLongShortsItemEditMode
+  case _setLongShortsItemList
+  case _setLongShortsItemCount
   
   // MARK: - Child Action
+  case shortsNewsItem(id: LongShortsItemState.ID, action: LongShortsItemAction)
 }
 
 public struct LongStorageNewsListEnvironment {
   public init() {}
 }
 
-public let longStorageNewsListReducer = Reducer.combine([
-  Reducer<
+public let longStorageNewsListReducer = Reducer<
   LongStorageNewsListState,
   LongStorageNewsListAction,
   LongStorageNewsListEnvironment
-  > { state, action, env in
+>.combine([
+  longShortsItemReducer
+    .forEach(
+      state: \LongStorageNewsListState.shortsNewsItems,
+      action: /LongStorageNewsListAction.shortsNewsItem(id:action:),
+      environment: { _ in
+        LongShortsItemEnvironment()
+      }
+    ),
+  Reducer { state, action, env in
     switch action {
+    case .editButtonTapped:
+      return Effect.concatenate([
+        Effect(value: ._setEditMode),
+        Effect(value: ._setLongShortsItemEditMode)
+      ])
+      
+    case .deleteButtonTapped:
+      return Effect.concatenate([
+        Effect(value: ._setEditMode),
+        Effect(value: ._setLongShortsItemList),
+        Effect(value: ._setLongShortsItemEditMode)
+      ])
+      
+    case .sortByTimeButtonTapped:
+      state.isLatestMode.toggle()
+      return .none
+      
+    case .sortByTypeButtonTapped:
+      // TODO: 타입에 따른 정렬 구현 필요
+      return .none
+      
+    case ._onAppear:
+      state.shortsNewsItems = LongStorageStub.items
+      return .none
+      
+    case ._setEditMode:
+      state.isInEditMode.toggle()
+      return .none
+      
+    case ._setLongShortsItemEditMode:
+      for index in 0..<state.shortsNewsItems.count {
+        state.shortsNewsItems[index].isInEditMode = state.isInEditMode
+        state.shortsNewsItems[index].cardState.isCardSelectable = !state.isInEditMode
+      }
+      return .none
+      
+    case ._setLongShortsItemList:
+      state.shortsNewsItems.removeAll(where: \.isSelected)
+      return Effect(value: ._setLongShortsItemCount)
+      
+    case ._setLongShortsItemCount:
+      state.shortsNewsItemsCount = state.shortsNewsItems.count
+      return .none
+      
     default: return .none
     }
   }
 ])
+
+// TODO: 코드 위치 변경 필요
+extension Date {
+  func yearMonthToString() -> String {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy년 M월"
+    dateFormatter.locale = Locale(identifier: "ko_KR")
+    dateFormatter.timeZone = TimeZone(identifier: "KST")
+    return dateFormatter.string(from: self)
+  }
+}

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageNewsListView.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageNewsListView.swift
@@ -21,17 +21,157 @@ public struct LongStorageNewsListView: View {
     WithViewStore(store) { viewStore in
       VStack(spacing: 0) {
         TopNavigationBar(
+          title: "오래 간직할 숏스",
           leftIcon: DesignSystem.Icons.iconNavigationLeft,
           leftIconButtonAction: {
             viewStore.send(.backButtonTapped)
+          },
+          rightText: viewStore.shortsNewsItemsCount == 0 ? nil : (viewStore.state.isInEditMode ? "삭제" : "편집"),
+          rightIconButtonAction: {
+            if !viewStore.state.isInEditMode {
+              viewStore.send(.editButtonTapped)
+            } else {
+              viewStore.send(.deleteButtonTapped)
+            }
           }
         )
         
-        Text("장기저장 뉴스 기사 리스트 화면")
-        
-        Spacer()
+        ScrollView {
+          VStack(spacing: 0) {
+            MonthInfoView(
+              month: viewStore.state.month,
+              shortsCompleteCount: viewStore.state.shortsCompleteCount
+            )
+            
+            Spacer()
+              .frame(height: viewStore.state.isInEditMode ? 40 : 48)
+
+            // 필터 뷰
+            if !viewStore.state.isInEditMode && viewStore.state.shortsNewsItemsCount != 0 {
+              FilterView(
+                isSortStatusByTime: viewStore.binding(
+                  get: { $0.isLatestMode },
+                  send: LongStorageNewsListAction.sortByTimeButtonTapped
+                ),
+                isSortStatusByType: viewStore.binding(
+                  get: { $0.isLatestMode },
+                  send: LongStorageNewsListAction.sortByTypeButtonTapped
+                )
+              )
+            }
+            
+            if viewStore.shortsNewsItemsCount == 0 {
+              // 저장한 숏스 없는 경우
+              Spacer()
+                .frame(height: 128)
+              
+              Text("아직 저장한 숏스가 없어요\n하루가 지나도 뉴스를 보고싶다면 저장해보세요")
+                .multilineTextAlignment(.center)
+                .font(.b14)
+                .foregroundColor(DesignSystem.Colors.grey70)
+                .padding(.horizontal, 24)
+            } else {
+              ForEachStore(
+                self.store.scope(
+                  state: \.shortsNewsItems,
+                  action: { .shortsNewsItem(id: $0, action: $1) }
+                )
+              ){
+                LongShortsItemView(store: $0)
+              }
+              .padding(.horizontal, 24)
+              .padding(.bottom, 16)
+            }
+          }
+          .frame(maxWidth: .infinity)
+        }
+        .padding(.bottom, 16)
+        .ignoresSafeArea()
+      }
+      .onAppear {
+        viewStore.send(._onAppear)
       }
     }
-    .navigationBarHidden(true)
+  }
+}
+
+private struct MonthInfoView: View {
+  private var month: String
+  private var shortsCompleteCount: Int
+  
+  fileprivate init(
+    month: String,
+    shortsCompleteCount: Int
+  ) {
+    self.month = month
+    self.shortsCompleteCount = shortsCompleteCount
+  }
+  
+  fileprivate var body: some View {
+    VStack(spacing: 8) {
+      Spacer()
+        .frame(height: 40)
+      
+      HStack(spacing: 16) {
+        Button {
+          // TODO: 기준 날짜보다 과거의 데이터 있을 떄에만 버튼 활성화
+        } label: {
+          DesignSystem.Icons.iconActiveCaretLeft
+        }
+        
+        Text(month)
+          .font(.b14)
+          .foregroundColor(DesignSystem.Colors.grey90)
+        
+        Button {
+          // TODO: 기준 날짜보다 최근인 데이터 있을 때에만 버튼 활성화
+        } label: {
+          DesignSystem.Icons.iconActiveCaretRight
+        }
+      }
+      
+      Text("\(shortsCompleteCount)숏스")
+        .font(.b24)
+        .foregroundColor(DesignSystem.Colors.grey100)
+    }
+  }
+}
+
+private struct FilterView: View {
+  @Binding fileprivate var isSortStatusByTime: Bool
+  @Binding fileprivate var isSortStatusByType: Bool // TODO: 카테고리 타입으로 변경 필요
+  
+  fileprivate var body: some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 0) {
+        Group {
+          Text(isSortStatusByTime ? "최신순" : "오래된 순")
+            .font(.r14)
+            .foregroundColor(DesignSystem.Colors.grey70)
+          
+          DesignSystem.Icons.iconChevronDown
+        }
+        .onTapGesture {
+          isSortStatusByTime.toggle()
+        }
+        
+        Spacer()
+        
+        Group {
+          Text("전체")
+            .font(.r14)
+            .foregroundColor(DesignSystem.Colors.grey70)
+          
+          DesignSystem.Icons.iconChevronDown
+        }
+        .onTapGesture {
+          isSortStatusByType.toggle()
+        }
+      }
+      .padding(.horizontal, 24)
+      
+      Spacer()
+        .frame(height: 16)
+    }
   }
 }

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageStub.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageStub.swift
@@ -1,0 +1,130 @@
+//
+//  LongStorageStub.swift
+//  LongStorageNewsList
+//
+//  Created by 안상희 on 2023/06/25.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import Foundation
+import IdentifiedCollections
+
+public struct LongStorageStub {
+  static var items: IdentifiedArrayOf<LongShortsItemState> = [
+    LongShortsItemState(
+      id: 0,
+      isInEditMode: false,
+      isSelected: false,
+      cardState: LongShortsCardState(
+        id: 0,
+        news: News(
+          id: 0,
+          title: "“따박따박 이자 받는게 최고야”...마음 편안한 예금, 금리 4% 재진입",
+          thumbnailImageUrl: nil,
+          newsLink: "https://naver.com",
+          press: "매시업",
+          writtenDateTime: "2023.06.03 04:24",
+          type: "경제"
+        ),
+        isCardSelectable: true,
+        isSelected: false
+      )
+    ),
+    LongShortsItemState(
+      id: 1,
+      isInEditMode: false,
+      isSelected: false,
+      cardState: LongShortsCardState(
+        id: 1,
+        news: News(
+          id: 1,
+          title: "“따박따박 이자 받는게 최고야”...마음 편안한 예금, 금리 4% 재진입",
+          thumbnailImageUrl: "https://static.mk.co.kr/facebook_mknews.jpg",
+          newsLink: "https://naver.com",
+          press: "매시업",
+          writtenDateTime: "2023.06.03 04:24",
+          type: "경제"
+        ),
+        isCardSelectable: true,
+        isSelected: false
+      )
+    ),
+    LongShortsItemState(
+      id: 2,
+      isInEditMode: false,
+      isSelected: false,
+      cardState: LongShortsCardState(
+        id: 2,
+        news: News(
+          id: 2,
+          title: "“따박따박 이자 받는게 최고야”...마음 편안한 예금, 금리 4% 재진입",
+          thumbnailImageUrl: "https://static.mk.co.kr/facebook_mknews.jpg",
+          newsLink: "https://naver.com",
+          press: "매시업",
+          writtenDateTime: "2023.06.03 04:24",
+          type: "경제"
+        ),
+        isCardSelectable: true,
+        isSelected: false
+      )
+    ),
+    LongShortsItemState(
+      id: 3,
+      isInEditMode: false,
+      isSelected: false,
+      cardState: LongShortsCardState(
+        id: 3,
+        news: News(
+          id: 3,
+          title: "“따박따박 이자 받는게 최고야”...마음 편안한 예금, 금리 4% 재진입",
+          thumbnailImageUrl: "https://static.mk.co.kr/facebook_mknews.jpg",
+          newsLink: "https://naver.com",
+          press: "매시업",
+          writtenDateTime: "2023.06.03 04:24",
+          type: "경제"
+        ),
+        isCardSelectable: true,
+        isSelected: false
+      )
+    ),
+    LongShortsItemState(
+      id: 4,
+      isInEditMode: false,
+      isSelected: false,
+      cardState: LongShortsCardState(
+        id: 4,
+        news: News(
+          id: 4,
+          title: "“따박따박 이자 받는게 최고야”...마음 편안한 예금, 금리 4% 재진입",
+          thumbnailImageUrl: "https://static.mk.co.kr/facebook_mknews.jpg",
+          newsLink: "https://naver.com",
+          press: "매시업",
+          writtenDateTime: "2023.06.03 04:24",
+          type: "경제"
+        ),
+        isCardSelectable: true,
+        isSelected: false
+      )
+    ),
+    LongShortsItemState(
+      id: 5,
+      isInEditMode: false,
+      isSelected: false,
+      cardState: LongShortsCardState(
+        id: 5,
+        news: News(
+          id: 5,
+          title: "“따박따박 이자 받는게 최고야”...마음 편안한 예금, 금리 4% 재진입",
+          thumbnailImageUrl: "https://static.mk.co.kr/facebook_mknews.jpg",
+          newsLink: "https://naver.com",
+          press: "매시업",
+          writtenDateTime: "2023.06.03 04:24",
+          type: "경제"
+        ),
+        isCardSelectable: true,
+        isSelected: false
+      )
+    )
+  ]
+
+}

--- a/Projects/Features/Scene/ShortStorageScene/ShortStorageNewsList/ShortStorageNewsListView.swift
+++ b/Projects/Features/Scene/ShortStorageScene/ShortStorageNewsList/ShortStorageNewsListView.swift
@@ -82,18 +82,16 @@ public struct ShortStorageNewsListView: View {
               Spacer()
                 .frame(height: 48)
               
-              VStack(spacing: 0) {
-                ForEachStore(
-                  self.store.scope(
-                    state: \.shortsNewsItems,
-                    action: { .shortsNewsItem(id: $0, action: $1) }
-                  )
-                ) {
-                  TodayShortsItemView(store: $0)
-                    .padding(.horizontal, 24)
-                }
-                .padding(.bottom, 16)
+              ForEachStore(
+                self.store.scope(
+                  state: \.shortsNewsItems,
+                  action: { .shortsNewsItem(id: $0, action: $1) }
+                )
+              ) {
+                TodayShortsItemView(store: $0)
               }
+              .padding(.horizontal, 24)
+              .padding(.bottom, 16)
             }
           }
           .frame(maxWidth: .infinity)


### PR DESCRIPTION
## 💻 Task

- 오래 간직할 숏스 화면 구현하기
- 뉴스 카드 클릭 시 웹 이동
- 편집모드에 따라 카드 삭제 가능

## 📱 실행 화면
![CleanShot 2023-06-26 at 13 32 58](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/95578975/68f54a4b-04eb-4ae3-86f9-850faa902c8c)

## 참고
- 정렬 기능, 월별 데이터 보기 기능은 API 연동하면서 같이 구현할 예정입니다. 