### PR TITLE
기능: 디자인 디테일 수정

### DIFF
--- a/Projects/DesignSystem/Resources/Colors/Colors.xcassets/MyPage/Contents.json
+++ b/Projects/DesignSystem/Resources/Colors/Colors.xcassets/MyPage/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/DesignSystem/Resources/Colors/Colors.xcassets/MyPage/mypage_border.colorset/Contents.json
+++ b/Projects/DesignSystem/Resources/Colors/Colors.xcassets/MyPage/mypage_border.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7E",
+          "green" : "0x6C",
+          "red" : "0x5D"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Features/Scene/MyPageScene/MyPage/MyInfo/MyShortsView.swift
+++ b/Projects/Features/Scene/MyPageScene/MyPage/MyInfo/MyShortsView.swift
@@ -70,7 +70,6 @@ struct MyShortsView: View {
       }
       .padding(.horizontal, 20)
       .padding(.vertical, 16)
-      // TODO: 블러 배경 수정 필요
       .background(Material.regularMaterial)
       .overlay(
         RoundedRectangle(cornerRadius: 8)
@@ -78,9 +77,8 @@ struct MyShortsView: View {
             LinearGradient(
               gradient: Gradient(
                 colors: [
-                  // TODO: 디자인시스템에 정의되지 않은 색상으로 수정 필요
-                  Color(hex: 0x556272).opacity(0.4),
-                  Color(hex: 0x3C414F).opacity(0.08)
+                  DesignSystem.Colors.mypageBorder.opacity(0.3),
+                  DesignSystem.Colors.mypageBorder.opacity(0.08)
                 ]
               ),
               startPoint: .topLeading,

--- a/Projects/Features/Scene/MyPageScene/MyPage/MyInfo/MyShortsView.swift
+++ b/Projects/Features/Scene/MyPageScene/MyPage/MyInfo/MyShortsView.swift
@@ -62,6 +62,7 @@ struct MyShortsView: View {
             )
           }
         }
+        .frame(maxWidth: .infinity)
         .padding(.horizontal, 24)
         .padding(.vertical, 12)
         .background(Color.white)
@@ -118,7 +119,7 @@ fileprivate struct ShortsInfoView: View {
         .font(.b18)
         .foregroundColor(fontColor)
     }
-    .frame(width: 103, height: 47)
+    .frame(maxWidth: .infinity)
     .background(Color.white)
   }
 }

--- a/Projects/Features/Scene/MyPageScene/MyPage/MyPageView.swift
+++ b/Projects/Features/Scene/MyPageScene/MyPage/MyPageView.swift
@@ -61,7 +61,7 @@ fileprivate struct MyPageBackgroundView: View {
   
   fileprivate var body: some View {
     ZStack {
-      Color(red: 255, green: 255, blue: 255)
+      Color.white
         .opacity(1)
         .edgesIgnoringSafeArea(.all)
       

--- a/Projects/Features/Scene/MyPageScene/MyPage/MyPageView.swift
+++ b/Projects/Features/Scene/MyPageScene/MyPage/MyPageView.swift
@@ -28,7 +28,6 @@ public struct MyPageView: View {
         )
         
         ZStack(alignment: .topTrailing) {
-          // TODO: 지구본 이미지 확정 시 수정 필요
           DesignSystem.Images.earth
             .frame(width: 106, height: 106)
             .padding(.trailing, 24)
@@ -48,11 +47,42 @@ public struct MyPageView: View {
         Spacer()
           .frame(height: 39)
         
-        // TODO: 디자인시스템 색상 정의되지 않은 부분으로 수정 필요
-        DesignSystem.Colors.blue100
+        DesignSystem.Colors.lightBlue
       }
     }
     .navigationBarHidden(true)
     .edgesIgnoringSafeArea(.bottom)
+    .myPageBackgroundView()
+  }
+}
+
+fileprivate struct MyPageBackgroundView: View {
+  fileprivate init() { }
+  
+  fileprivate var body: some View {
+    ZStack {
+      Color(red: 255, green: 255, blue: 255)
+        .opacity(1)
+        .edgesIgnoringSafeArea(.all)
+      
+      GeometryReader { geometry in
+        Circle()
+          .fill(
+            Color(red: 45/255, green: 205/255, blue: 255/255, opacity: 0.5)
+          )
+          .frame(width: 188, height: 188)
+          .blur(radius: 96)
+          .offset(x: -43, y: 178)
+      }
+    }
+  }
+}
+
+extension View {
+  fileprivate func myPageBackgroundView() -> some View {
+    ZStack {
+      MyPageBackgroundView()
+      self
+    }
   }
 }


### PR DESCRIPTION
## Task

- 오늘의숏스, 오래 간직할 숏스 포함하는 뷰랑 바깥 뷰 사이의 패딩이 기기마다 달라지는 이슈 수정
- 이번 달 ~숏스 중을 포함하는 뷰 배경 블러 처리
- 이번 달 ~숏스 중에 해당하는 뷰 테두리 색상 변경

## 📱 실행 화면
<img width="532" alt="CleanShot 2023-06-26 at 22 06 53@2x" src="https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/95578975/c637a1fb-e4ab-48c0-9da6-c784be814ff6">


