### PR TITLE
기능: 오늘의 숏스 저장 애니메이션 및 API 연결

### DIFF
--- a/Projects/Core/Models/Network/NewsCard/RequestDTO/SaveNewsCardRequestDTO.swift
+++ b/Projects/Core/Models/Network/NewsCard/RequestDTO/SaveNewsCardRequestDTO.swift
@@ -1,0 +1,17 @@
+//
+//  SaveNewsCardRequestDTO.swift
+//  Models
+//
+//  Created by 김영균 on 2023/06/26.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import Foundation
+
+public struct SaveNewsCardRequestDTO: Encodable {
+  public var newsCardId: Int
+  
+  public init(newsCardId: Int) {
+    self.newsCardId = newsCardId
+  }
+}

--- a/Projects/Core/Services/NewsCard/NewsCardAPI.swift
+++ b/Projects/Core/Services/NewsCard/NewsCardAPI.swift
@@ -12,17 +12,21 @@ import Models
 
 public enum NewsCardAPI {
   case getAllNewsCards(Date, Int, Int)
+  case saveNewsCard(Int)
 }
 
 extension NewsCardAPI: TargetType {
   public var baseURL: URL {
-    return URL(string: "http://3.38.65.72:8080")!
+    return URL(string: "http://3.38.65.72:8080/v1")!
   }
   
   public var path: String {
     switch self {
     case .getAllNewsCards:
-      return "/v1/member-news-card"
+      return "/member-news-card"
+    
+    case .saveNewsCard:
+      return "/member/news-card"
     }
   }
   
@@ -30,6 +34,9 @@ extension NewsCardAPI: TargetType {
     switch self {
     case .getAllNewsCards:
       return .get
+      
+    case .saveNewsCard:
+      return .post
     }
   }
   
@@ -45,16 +52,20 @@ extension NewsCardAPI: TargetType {
         parameters: requestDTO.toDictionary,
         encoding: .queryString
       )
+      
+    case let .saveNewsCard(newsCardId):
+      let requestDTO = SaveNewsCardRequestDTO(newsCardId: newsCardId)
+      return .requestJSONEncodable(requestDTO)
     }
   }
   
   public var headers: [String: String]? {
-    return ["Content-Type": "application/json"]
+    return .none
   }
   
   public var sampleData: Data {
     switch self {
-    case .getAllNewsCards:
+    default:
       return Data()
     }
   }

--- a/Projects/Core/Services/NewsCard/NewsCardAPI.swift
+++ b/Projects/Core/Services/NewsCard/NewsCardAPI.swift
@@ -59,10 +59,6 @@ extension NewsCardAPI: TargetType {
     }
   }
   
-  public var headers: [String: String]? {
-    return .none
-  }
-  
   public var sampleData: Data {
     switch self {
     default:

--- a/Projects/Core/Services/NewsCard/NewsCardService.swift
+++ b/Projects/Core/Services/NewsCard/NewsCardService.swift
@@ -22,6 +22,8 @@ public struct NewsCardService {
     _ cursorId: Int,
     _ pagingSize: Int
   ) -> Effect<[NewsCard], Error>
+  
+  public var saveNewsCard: (_ newsCardId: Int) -> Effect<VoidResponse?, Error>
 }
 
 extension NewsCardService {
@@ -35,6 +37,15 @@ extension NewsCardService {
         )
         .compactMap { $0 }
         .map { $0.map { $0.toDomain }}
+        .eraseToEffect()
+    },
+    saveNewsCard: { newsCardId in
+      return Provider<NewsCardAPI>
+        .init()
+        .request(
+          NewsCardAPI.saveNewsCard(newsCardId),
+          type: VoidResponse.self
+        )
         .eraseToEffect()
     }
   )

--- a/Projects/Core/Services/UserDefaults/UserDefaultsService.swift
+++ b/Projects/Core/Services/UserDefaults/UserDefaultsService.swift
@@ -11,14 +11,20 @@ import CombineExt
 import ComposableArchitecture
 import Foundation
 
+public enum UserDefaultsKey: String {
+  case registered
+  case hasLanched
+  case userID
+}
+
 public struct UserDefaultsService {
-  public let save: (Bool) -> Effect<Void, Never>
-  public let load: () -> Effect<Bool, Never>
+  public let save: (UserDefaultsKey, Bool) -> Effect<Void, Never>
+  public let load: (UserDefaultsKey) -> Effect<Bool, Never>
   public let saveUserID: (String) -> Effect<Void, Never>
   
   private init(
-    save: @escaping (Bool) -> Effect<Void, Never>,
-    load: @escaping () -> Effect<Bool, Never>,
+    save: @escaping (UserDefaultsKey, Bool) -> Effect<Void, Never>,
+    load: @escaping (UserDefaultsKey) -> Effect<Bool, Never>,
     saveUserID: @escaping (String) -> Effect<Void, Never>
   ) {
     self.save = save
@@ -29,17 +35,17 @@ public struct UserDefaultsService {
 
 public extension UserDefaultsService {
   static var live = Self.init(
-    save: { value in
+    save: { key, value in
       return Publishers.Create<Void, Never>(factory: { subscriber -> Cancellable in
-        subscriber.send(UserDefaults.standard.set(value, forKey: "registered"))
+        subscriber.send(UserDefaults.standard.set(value, forKey: key.rawValue))
         subscriber.send(completion: .finished)
         return AnyCancellable({})
       })
       .eraseToEffect()
     },
-    load: {
+    load: { key in
       return Publishers.Create<Bool, Never>(factory: { subscriber -> Cancellable in
-        subscriber.send(UserDefaults.standard.bool(forKey: "registered"))
+        subscriber.send(UserDefaults.standard.bool(forKey: key.rawValue))
         subscriber.send(completion: .finished)
         return AnyCancellable({})
       })
@@ -47,7 +53,7 @@ public extension UserDefaultsService {
     },
     saveUserID: { value in
       return Publishers.Create<Void, Never>(factory: { subscriber -> Cancellable in
-        subscriber.send(UserDefaults.standard.set(value, forKey: "userID"))
+        subscriber.send(UserDefaults.standard.set(value, forKey: UserDefaultsKey.userID.rawValue))
         subscriber.send(completion: .finished)
         return AnyCancellable({})
       })

--- a/Projects/Core/Services/UserDefaults/UserDefaultsService.swift
+++ b/Projects/Core/Services/UserDefaults/UserDefaultsService.swift
@@ -13,7 +13,7 @@ import Foundation
 
 public enum UserDefaultsKey: String {
   case registered
-  case hasLanched
+  case hasLaunched
   case userID
 }
 

--- a/Projects/Features/Coordinator/AppCoordinator/AppScreenCore.swift
+++ b/Projects/Features/Coordinator/AppCoordinator/AppScreenCore.swift
@@ -87,6 +87,7 @@ internal let appScreenReducer = Reducer<
       environment: {
         TabBarEnvironment(
           mainQueue: $0.mainQueue,
+          userDefaultsService: $0.userDefaultsService,
           appVersionService: $0.appVersionService,
           newsCardService: $0.newsCardService,
           categoryService: $0.categoryService

--- a/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
@@ -35,15 +35,18 @@ public enum MainCoordinatorAction: IndexedRouterAction {
 
 public struct MainCoordinatorEnvironment {
   fileprivate let mainQueue: AnySchedulerOf<DispatchQueue>
+  fileprivate let userDefaultsService: UserDefaultsService
   fileprivate let newsCardService: NewsCardService
   fileprivate let categoryService: CategoryService
   
   public init(
     mainQueue: AnySchedulerOf<DispatchQueue>,
+    userDefaultsService: UserDefaultsService,
     newsCardService: NewsCardService,
     categoryService: CategoryService
   ) {
     self.mainQueue = mainQueue
+    self.userDefaultsService = userDefaultsService
     self.newsCardService = newsCardService
     self.categoryService = categoryService
   }
@@ -58,6 +61,7 @@ public let mainCoordinatorReducer: Reducer<
     environment: {
       MainScreenEnvironment(
         mainQueue: $0.mainQueue,
+        userDefaultsService: $0.userDefaultsService,
         newsCardService: $0.newsCardService,
         categoryService: $0.categoryService
       )

--- a/Projects/Features/Coordinator/MainCoordinator/MainScreenCore.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainScreenCore.swift
@@ -23,15 +23,18 @@ public enum MainScreenAction {
 
 internal struct MainScreenEnvironment {
   fileprivate let mainQueue: AnySchedulerOf<DispatchQueue>
+  fileprivate let userDefaultsService: UserDefaultsService
   fileprivate let newsCardService: NewsCardService
   fileprivate let categoryService: CategoryService
   
   internal init(
     mainQueue: AnySchedulerOf<DispatchQueue>,
+    userDefaultsService: UserDefaultsService,
     newsCardService: NewsCardService,
     categoryService: CategoryService
   ) {
     self.mainQueue = mainQueue
+    self.userDefaultsService = userDefaultsService
     self.newsCardService = newsCardService
     self.categoryService = categoryService
   }
@@ -49,6 +52,7 @@ internal let mainScreenReducer = Reducer<
       environment: {
         MainEnvironment(
           mainQueue: $0.mainQueue,
+          userDefaultsService: $0.userDefaultsService,
           newscardService: $0.newsCardService,
           categoryService: $0.categoryService
         )

--- a/Projects/Features/Scene/MainScene/Main/MainCore.swift
+++ b/Projects/Features/Scene/MainScene/Main/MainCore.swift
@@ -93,7 +93,7 @@ public let mainReducer = Reducer.combine([
     .pullback(
       state: \.newsCardScrollState,
       action: /MainAction.newsCardScroll,
-      environment: { _ in NewsCardScrollEnvironmnet() }
+      environment: { NewsCardScrollEnvironmnet(newsCardService: $0.newsCardService) }
     ),
   saveGuideReducer
     .optional()
@@ -199,6 +199,9 @@ public let mainReducer = Reducer.combine([
       if newsCardsCount - currentScrollIndex > Constant.pagingCriticalPoint { return .none }
       state.cursorPage += 1
       return Effect(value: ._fetchNewsCards(.continuousPaging))
+      
+    case .newsCardScroll(.newsCard(id: _, action: ._saveNewsCard)):
+      return Effect(value: .saveGuide(._startAnimation))
       
     default:
       return .none

--- a/Projects/Features/Scene/MainScene/Main/MainView.swift
+++ b/Projects/Features/Scene/MainScene/Main/MainView.swift
@@ -42,6 +42,7 @@ public struct MainView: View {
           NewsCardScrollView(store: store)
             .frame(height: viewStore.newsCardLayout.size.height)
         }
+        
         Spacer()
           .frame(height: 24)
         

--- a/Projects/Features/Scene/MainScene/Main/MainView.swift
+++ b/Projects/Features/Scene/MainScene/Main/MainView.swift
@@ -41,11 +41,17 @@ public struct MainView: View {
         ) { store in
           NewsCardScrollView(store: store)
             .frame(height: viewStore.newsCardLayout.size.height)
-          
-          Spacer()
-            .frame(height: 24)
-          
-          SaveTextView()
+        }
+        Spacer()
+          .frame(height: 24)
+        
+        IfLetStore(
+          store.scope(
+            state: \.saveGuideState,
+            action: MainAction.saveGuide
+          )
+        ) { store in
+          SaveGuideView(store: store)          
         }
         
         Spacer()
@@ -57,16 +63,5 @@ public struct MainView: View {
     }
     .shortsBackgroundView()
     .navigationBarHidden(true)
-  }
-}
-
-private struct SaveTextView: View {
-  fileprivate var body: some View {
-    VStack(spacing: 8) {
-      DesignSystem.Icons.caretDown
-      Text("아래로 내려서 저장하기")
-        .font(.b14)
-        .foregroundColor(DesignSystem.Colors.grey70)
-    }
   }
 }

--- a/Projects/Features/Scene/MainScene/Main/NewsCard/NewsCardScrollCore.swift
+++ b/Projects/Features/Scene/MainScene/Main/NewsCard/NewsCardScrollCore.swift
@@ -9,6 +9,7 @@
 import ComposableArchitecture
 import Foundation
 import Models
+import Services
 
 public struct NewsCardLayout: Equatable {
   var ratio: CGSize = .zero
@@ -68,7 +69,13 @@ public enum NewsCardScrollAction {
   case newsCard(id: Int, action: NewsCardAction)
 }
 
-public struct NewsCardScrollEnvironmnet {}
+public struct NewsCardScrollEnvironmnet {
+  fileprivate let newsCardService: NewsCardService
+  
+  public init(newsCardService: NewsCardService) {
+    self.newsCardService = newsCardService
+  }
+}
 
 public let newsCardScrollReducer = Reducer<
   NewsCardScrollState,
@@ -79,7 +86,7 @@ public let newsCardScrollReducer = Reducer<
     .forEach(
       state: \.newsCards,
       action: /NewsCardScrollAction.newsCard(id:action:),
-      environment: { _ in NewsCardEnvironment() }
+      environment: { NewsCardEnvironment(newsCardService: $0.newsCardService) }
     ),
   Reducer { state, action, environment in
     switch action {

--- a/Projects/Features/Scene/MainScene/Main/NewsCard/NewsCardView.swift
+++ b/Projects/Features/Scene/MainScene/Main/NewsCard/NewsCardView.swift
@@ -56,6 +56,10 @@ struct NewsCardView: View {
             deviceRatio: viewStore.layout.ratio
           )
         }
+        .gesture(
+          DragGesture()
+            .onEnded { viewStore.send(.dragGestureEnded($0.translation)) }
+        )
       }
     }
   }

--- a/Projects/Features/Scene/MainScene/Main/SaveGuide/SaveGuideCore.swift
+++ b/Projects/Features/Scene/MainScene/Main/SaveGuide/SaveGuideCore.swift
@@ -25,7 +25,6 @@ public enum SaveGuideAction: Equatable {
   
   // MARK: - Inner SetState Action  
   case _setCaretDownOffset(CGSize)
-  
 }
 
 public struct SaveGuideEnvironment {

--- a/Projects/Features/Scene/MainScene/Main/SaveGuide/SaveGuideCore.swift
+++ b/Projects/Features/Scene/MainScene/Main/SaveGuide/SaveGuideCore.swift
@@ -1,0 +1,87 @@
+//
+//  SaveGuideCore.swift
+//  Splash
+//
+//  Created by 김영균 on 2023/06/26.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import ComposableArchitecture
+import Foundation
+import Services
+
+public struct SaveGuideState: Equatable {
+  var caretDownOffset: CGSize = .zero
+  
+  public init() { }
+}
+
+public enum SaveGuideAction: Equatable {
+  // MARK: - Inner Business Action
+  case _onAppear
+  case _updateLaunchStatus
+  case _firstLaunchAnimation
+  case _startAnimation
+  
+  // MARK: - Inner SetState Action  
+  case _setCaretDownOffset(CGSize)
+  
+}
+
+public struct SaveGuideEnvironment {
+  let mainQueue: AnySchedulerOf<DispatchQueue>
+  let userDefaultsService: UserDefaultsService
+  
+  public init(
+    mainQueue: AnySchedulerOf<DispatchQueue>,
+    userDefaultsService: UserDefaultsService
+  ) {
+    self.mainQueue = mainQueue
+    self.userDefaultsService = userDefaultsService
+  }
+}
+
+public let saveGuideReducer = Reducer<
+  SaveGuideState,
+  SaveGuideAction,
+  SaveGuideEnvironment
+> { state, action, env in
+  switch action {
+  case ._onAppear:
+    return env.userDefaultsService.load(.hasLanched)
+      .flatMapLatest { hasLaunched -> Effect<SaveGuideAction, Never> in
+        if !hasLaunched {
+          return Effect.merge(
+            Effect(value: ._updateLaunchStatus),
+            Effect(value: ._startAnimation)
+          )
+        } else {
+          return .none
+        }
+      }
+      .eraseToEffect()
+    
+  case ._updateLaunchStatus:
+    print("isFirstLaunced")
+    return env.userDefaultsService.save(.hasLanched, true)
+      .fireAndForget()
+    
+  case ._firstLaunchAnimation:
+    return Effect.concatenate(
+      Effect(value: ._startAnimation).delay(for: 2, scheduler: env.mainQueue).eraseToEffect(),
+      Effect(value: ._startAnimation).delay(for: 2, scheduler: env.mainQueue).eraseToEffect(),
+      Effect(value: ._startAnimation).delay(for: 2, scheduler: env.mainQueue).eraseToEffect()
+    )
+    
+  case ._startAnimation:
+    return .run { send in
+      await send(._setCaretDownOffset(.init(width: 0, height: 10)))
+      try await env.mainQueue.sleep(for: 1)
+      await send(._setCaretDownOffset(.zero))
+    }
+    
+  case let ._setCaretDownOffset(offset):
+    state.caretDownOffset = offset
+    return .none
+  }
+}

--- a/Projects/Features/Scene/MainScene/Main/SaveGuide/SaveGuideCore.swift
+++ b/Projects/Features/Scene/MainScene/Main/SaveGuide/SaveGuideCore.swift
@@ -47,7 +47,7 @@ public let saveGuideReducer = Reducer<
 > { state, action, env in
   switch action {
   case ._onAppear:
-    return env.userDefaultsService.load(.hasLanched)
+    return env.userDefaultsService.load(.hasLaunched)
       .flatMapLatest { hasLaunched -> Effect<SaveGuideAction, Never> in
         if !hasLaunched {
           return Effect.merge(
@@ -61,7 +61,7 @@ public let saveGuideReducer = Reducer<
       .eraseToEffect()
     
   case ._updateLaunchStatus:
-    return env.userDefaultsService.save(.hasLanched, true)
+    return env.userDefaultsService.save(.hasLaunched, true)
       .fireAndForget()
     
   case ._firstLaunchAnimation:

--- a/Projects/Features/Scene/MainScene/Main/SaveGuide/SaveGuideCore.swift
+++ b/Projects/Features/Scene/MainScene/Main/SaveGuide/SaveGuideCore.swift
@@ -53,7 +53,7 @@ public let saveGuideReducer = Reducer<
         if !hasLaunched {
           return Effect.merge(
             Effect(value: ._updateLaunchStatus),
-            Effect(value: ._startAnimation)
+            Effect(value: ._firstLaunchAnimation)
           )
         } else {
           return .none
@@ -62,7 +62,6 @@ public let saveGuideReducer = Reducer<
       .eraseToEffect()
     
   case ._updateLaunchStatus:
-    print("isFirstLaunced")
     return env.userDefaultsService.save(.hasLanched, true)
       .fireAndForget()
     

--- a/Projects/Features/Scene/MainScene/Main/SaveGuide/SaveGuideCore.swift
+++ b/Projects/Features/Scene/MainScene/Main/SaveGuide/SaveGuideCore.swift
@@ -75,8 +75,9 @@ public let saveGuideReducer = Reducer<
   case ._startAnimation:
     return .run { send in
       await send(._setCaretDownOffset(.init(width: 0, height: 10)))
-      try await env.mainQueue.sleep(for: 1)
-      await send(._setCaretDownOffset(.zero))
+      DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+        send(._setCaretDownOffset(.init(width: 0, height: 0)))
+      }
     }
     
   case let ._setCaretDownOffset(offset):

--- a/Projects/Features/Scene/MainScene/Main/SaveGuide/SaveGuideView.swift
+++ b/Projects/Features/Scene/MainScene/Main/SaveGuide/SaveGuideView.swift
@@ -1,0 +1,34 @@
+//
+//  SaveGuideView.swift
+//  Splash
+//
+//  Created by 김영균 on 2023/06/26.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import ComposableArchitecture
+import DesignSystem
+import SwiftUI
+
+struct SaveGuideView: View {
+  private let store: Store<SaveGuideState, SaveGuideAction>
+  
+  init(store: Store<SaveGuideState, SaveGuideAction>) {
+    self.store = store
+  }
+  
+  var body: some View {
+    WithViewStore(store) { viewStore in
+      VStack(spacing: 8) {
+        DesignSystem.Icons.caretDown
+          .offset(viewStore.caretDownOffset)
+          .animation(.spring(), value: viewStore.caretDownOffset)
+          
+        Text("아래로 내려서 저장하기")
+          .font(.b14)
+          .foregroundColor(DesignSystem.Colors.grey70)
+      }
+      .onAppear { viewStore.send(._onAppear) }
+    }
+  }
+}

--- a/Projects/Features/Scene/SetCategoryScene/SetCategory/SetCategoryCore.swift
+++ b/Projects/Features/Scene/SetCategoryScene/SetCategory/SetCategoryCore.swift
@@ -75,7 +75,7 @@ public let setCategoryReducer = Reducer.combine([
       return Effect(value: ._saveConnectHistory)
       
     case ._saveConnectHistory:
-      return env.userDefaultsService.save(true)
+      return env.userDefaultsService.save(.registered, true)
         .map({ _ -> SetCategoryAction in
           return ._sendSelectedCategory
         })

--- a/Projects/Features/Scene/SplashScene/Splash/SplashCore.swift
+++ b/Projects/Features/Scene/SplashScene/Splash/SplashCore.swift
@@ -39,7 +39,7 @@ public let splashReducer = Reducer.combine([
       return Effect(value: ._checkConnectHistory)
       
     case ._checkConnectHistory:
-      return env.userDefaultsService.load()
+      return env.userDefaultsService.load(.registered)
         .map({ status -> SplashAction in
           if status {
             return ._moveToHome

--- a/Projects/Features/Scene/TabBarScene/TabBar/TabBarCore.swift
+++ b/Projects/Features/Scene/TabBarScene/TabBar/TabBarCore.swift
@@ -55,17 +55,20 @@ public enum TabBarAction {
 
 public struct TabBarEnvironment {
   fileprivate let mainQueue: AnySchedulerOf<DispatchQueue>
+  fileprivate let userDefaultsService: UserDefaultsService
   let appVersionService: AppVersionService
   fileprivate let newsCardService: NewsCardService
   fileprivate let categoryService: CategoryService
   
   public init(
     mainQueue: AnySchedulerOf<DispatchQueue>,
+    userDefaultsService: UserDefaultsService,
     appVersionService: AppVersionService,
     newsCardService: NewsCardService,
     categoryService: CategoryService
   ) {
     self.mainQueue = mainQueue
+    self.userDefaultsService = userDefaultsService
     self.appVersionService = appVersionService
     self.newsCardService = newsCardService
     self.categoryService = categoryService
@@ -92,6 +95,7 @@ public let tabBarReducer = Reducer<
       environment: {
         MainCoordinatorEnvironment(
           mainQueue: $0.mainQueue,
+          userDefaultsService: $0.userDefaultsService,
           newsCardService: $0.newsCardService,
           categoryService: $0.categoryService
         )

--- a/Projects/Features/Scene/TabBarScene/TabBar/TabBarCore.swift
+++ b/Projects/Features/Scene/TabBarScene/TabBar/TabBarCore.swift
@@ -21,6 +21,7 @@ public struct TabBarState: Equatable {
   public var categoryBottomSheet: BottomSheetState
   public var selectedTab: TabBarItem = .house
   public var isTabHidden: Bool = false
+  public var toastMessage: String?
   
   public init(
     hotKeyword: HotKeywordCoordinatorState,
@@ -42,9 +43,12 @@ public enum TabBarAction {
   case tabSelected(TabBarItem)
   
   // MARK: - Inner Business Action
+  case _presentToast(String)
+  case _hideToast
   
   // MARK: - Inner SetState Action
   case _setTabHiddenStatus(Bool)
+  case _setToastMessage(String?)
   
   // MARK: - Child Action
   case hotKeyword(HotKeywordCoordinatorAction)
@@ -73,6 +77,10 @@ public struct TabBarEnvironment {
     self.newsCardService = newsCardService
     self.categoryService = categoryService
   }
+}
+
+enum TabBarID: Hashable {
+  case _presentToast
 }
 
 public let tabBarReducer = Reducer<
@@ -129,15 +137,52 @@ public let tabBarReducer = Reducer<
       state.selectedTab = tab
       return .none
       
+    case let ._presentToast(toastMessage):
+      return .concatenate(
+        Effect(value: ._setToastMessage(toastMessage)),
+        Effect.cancel(id: TabBarID._presentToast),
+        Effect(value: ._hideToast)
+          .delay(for: 2, scheduler: env.mainQueue)
+          .eraseToEffect()
+          .cancellable(id: TabBarID._presentToast, cancelInFlight: true)
+      )
+      
+    case ._hideToast:
+      return Effect(value: ._setToastMessage(nil))
+    
+    case ._setTabHiddenStatus(let status):
+      state.isTabHidden = status
+      return .none
+      
+    case let ._setToastMessage(message):
+      state.toastMessage = message
+      return .none
+      
     case let .main(.routeAction(_, action: .main(.showCategoryBottomSheet(categories)))):
       return Effect.concatenate(
         Effect(value: .categoryBottomSheet(._setSelectedCategories(categories))),
         Effect(value: .categoryBottomSheet(._setIsPresented(true)))
       )
       
-    case ._setTabHiddenStatus(let status):
-      state.isTabHidden = status
-      return .none
+    case let .main(
+      .routeAction(
+        _, action: .main(
+          .newsCardScroll(
+            .newsCard(
+              id: _,
+              action: ._handleSaveNewsCardResponse(response)
+            )
+          )
+        )
+      )
+    ):
+      switch response {
+      case .success:
+        return Effect(value: ._presentToast("오늘 읽을 숏스에 저장됐어요:)"))
+        
+      case .failure:
+        return Effect(value: ._presentToast("인터넷이 불안정해서 저장되지 못했어요."))
+      }
       
     case .myPage(.routeAction(_, action: .myPage(.settingButtonTapped))):
       return Effect(value: ._setTabHiddenStatus(true))

--- a/Projects/Features/Scene/TabBarScene/TabBar/TabBarView.swift
+++ b/Projects/Features/Scene/TabBarScene/TabBar/TabBarView.swift
@@ -65,6 +65,15 @@ public struct TabBarView: View {
           selection: viewStore.binding(get: { $0.selectedTab }, send: TabBarAction.tabSelected)
         )
       }
+      .apply(content: { view in
+        WithViewStore(store.scope(state: \.toastMessage)) { toastMessageViewStore in
+          view.toast(
+            text: toastMessageViewStore.state,
+            toastType: buildToastType(message: toastMessageViewStore.state),
+            toastOffset: -38
+          )
+        }
+      })
       .bottomSheet(
         isPresented: viewStore.binding(
           get: \.categoryBottomSheet.isPresented,
@@ -104,4 +113,15 @@ public struct TabBarView: View {
       })
     }
   }
+}
+
+private func buildToastType(message: String?) -> ToastType {
+  guard let message = message else { return .basic }
+  if message == "오늘 읽을 숏스에 저장됐어요:)" {
+    return .info
+  }
+  if message == "인터넷이 불안정해서 저장되지 못했어요." {
+    return .warning
+  }
+  return .basic
 }


### PR DESCRIPTION
## Task
오늘의 숏스 저장 애니메이션과 API 구현했습니다.
close #71  

## 참고
- 다음 작업은 저장을 하면 다음 뉴스카드로 넘어가는 것과 로딩 인디케이터입니다.

## 설명
- <img width="136" alt="image" src="https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/48887389/5b0b570d-a814-47bb-8449-b66a20df01b5">

  👆에서 발생하는 애니메이션을 SaveGuideCore에서 관리했습니다.~!

- 뉴스 카드 코어에서 아래로 드래그액션을 캐치하고 저장을 시도합니다~!
```swift
/// NewsCardCore.swift
 case let .dragGestureEnded(translation):
    if isDraggedVertically(state: state, with: translation) {
      return Effect(value: ._saveNewsCard)
    }
    return .none
    
  case ._saveNewsCard:
    return env.newsCardService.saveNewsCard(state.newsCard.id)
      .catchToEffect(NewsCardAction._handleSaveNewsCardResponse)
``` 

- 메인에서 저장하는 액션을 캐치하고 SaveGuideCore의 애니메이션 액션을 실행합니다~!
```swift
/// MainCore.swift
case .newsCardScroll(.newsCard(id: _, action: ._saveNewsCard)):
      return Effect(value: .saveGuide(._startAnimation))
```

- SaveGuideCore에서 애니메이션을 실행합니다. 
(근데 `_setCaretDownOffset` 액션을 1초 뒤에 실행하는데 sleep을 주는게 맞는지 모르겠습니다.)
```swift
/// SaveGuideCore.swift
case ._startAnimation:
    return .run { send in
      await send(._setCaretDownOffset(.init(width: 0, height: 10)))
      try await env.mainQueue.sleep(for: 1)
      await send(._setCaretDownOffset(.zero))
    }
```

## 스크린샷
![Simulator Screen Recording - iPhone 14 Pro - 2023-06-26 at 21 34 12](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/48887389/d0631ba4-8007-4344-8fe4-904e834ff47a)
