### PR TITLE
기능: 핫 키워드 눌렀을 때, 뉴스 목록 화면 이동 구현

### DIFF
--- a/Projects/Core/Models/Network/NewsCard/ResponseDTO/NewsCardsResponseDTO.swift
+++ b/Projects/Core/Models/Network/NewsCard/ResponseDTO/NewsCardsResponseDTO.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-public struct NewsCardsResponseDTO: Decodable {
-  let id: Int
-  let keywords: String
-  let category: String
-  let crawledDateTime: String
+public struct NewsCardsResponseDTO: Decodable, Equatable {
+  public let id: Int
+  public let keywords: String
+  public let category: String
+  public let crawledDateTime: String
 }
 
 public extension NewsCardsResponseDTO {

--- a/Projects/Core/Services/HotKeyword/HotKeywordAPI.swift
+++ b/Projects/Core/Services/HotKeyword/HotKeywordAPI.swift
@@ -12,6 +12,7 @@ import Models
 
 public enum HotKeywordAPI {
   case fetchHotKeyword
+  case fetchKeywordShorts(keyword: String)
 }
 
 extension HotKeywordAPI: TargetType {
@@ -23,12 +24,14 @@ extension HotKeywordAPI: TargetType {
     switch self {
     case .fetchHotKeyword:
       return "/hot-keywords"
+    case let .fetchKeywordShorts(keyword):
+      return "/hot-keywords/\(keyword)"
     }
   }
   
   public var method: HTTPMethod {
     switch self {
-    case .fetchHotKeyword:
+    case .fetchHotKeyword, .fetchKeywordShorts:
       return .get
     }
   }
@@ -36,9 +39,11 @@ extension HotKeywordAPI: TargetType {
   public var task: Task {
     switch self {
     case .fetchHotKeyword:
-      let targetTime = DateFormatter.hotKeywordDateFormatter.string(from: Date())
+      return .requestPlain
+    case .fetchKeywordShorts:
       return .requestParameters(
-        parameters: ["targetTime": targetTime],
+        // lina-TODO: parameter 고정으로 가는건지 확인필요
+        parameters: ["cursorId": 0, "size": 10],
         encoding: .queryString
       )
     }

--- a/Projects/Core/Services/HotKeyword/HotKeywordAPI.swift
+++ b/Projects/Core/Services/HotKeyword/HotKeywordAPI.swift
@@ -42,7 +42,6 @@ extension HotKeywordAPI: TargetType {
       return .requestPlain
     case .fetchKeywordShorts:
       return .requestParameters(
-        // lina-TODO: parameter 고정으로 가는건지 확인필요
         parameters: ["cursorId": 0, "size": 10],
         encoding: .queryString
       )

--- a/Projects/Core/Services/HotKeyword/HotKeywordService.swift
+++ b/Projects/Core/Services/HotKeyword/HotKeywordService.swift
@@ -14,12 +14,7 @@ import Models
 
 public struct HotKeywordService {
   public var fetchHotKeyword: () -> Effect<HotKeywordDTO, Error>
-  
-  private init(
-    fetchHotKeyword: @escaping () -> Effect<HotKeywordDTO, Error>
-  ) {
-    self.fetchHotKeyword = fetchHotKeyword
-  }
+  public var fetchKeywordShorts: (_ keyword: String) -> Effect<[NewsCardsResponseDTO], Error>
 }
 
 extension HotKeywordService {
@@ -30,6 +25,16 @@ extension HotKeywordService {
         .request(
           HotKeywordAPI.fetchHotKeyword,
           type: HotKeywordDTO.self
+        )
+        .compactMap { $0 }
+        .eraseToEffect()
+    },
+    fetchKeywordShorts: { keyword in
+      return Provider<HotKeywordAPI>
+        .init()
+        .request(
+          HotKeywordAPI.fetchKeywordShorts(keyword: keyword),
+          type: [NewsCardsResponseDTO].self
         )
         .compactMap { $0 }
         .eraseToEffect()

--- a/Projects/Features/Coordinator/HotKeywordCoordinator/HotKeywordCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/HotKeywordCoordinator/HotKeywordCoordinatorCore.swift
@@ -8,6 +8,7 @@
 
 import ComposableArchitecture
 import HotKeyword
+import NewsCardCoordinator
 import Services
 import SwiftUI
 import TCACoordinators
@@ -60,8 +61,15 @@ public let hotKeywordCoordinatorReducer: Reducer<
     Reducer { state, action, env in
       switch action {
         // lina-TODO: 값 넘겨서 연결 후 연결 동작 확인 필요(어떻게 넘겨줄지 확인 필요)
-      case .routeAction(_, action: .hotKeyword(.hotKeywordCircleTapped)):
-        state.routes.push(.newCard(.init()))
+      case let .routeAction(_, action: .hotKeyword(.showKeywordNewsList(keyword, newsItems))):
+        state.routes.push(.newCard(.init(routes: [
+          .root(
+            .newsList(
+              .init(keywordTitle: keyword, newsItems: newsItems)
+            ),
+            embedInNavigationView: true
+          )
+        ])))
         return .none
 
       case .routeAction(_, action: .newCard(.routeAction(_, action: .newsList(.backButtonTapped)))):

--- a/Projects/Features/Coordinator/HotKeywordCoordinator/HotKeywordCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/HotKeywordCoordinator/HotKeywordCoordinatorCore.swift
@@ -60,7 +60,6 @@ public let hotKeywordCoordinatorReducer: Reducer<
   .withRouteReducer(
     Reducer { state, action, env in
       switch action {
-        // lina-TODO: 값 넘겨서 연결 후 연결 동작 확인 필요(어떻게 넘겨줄지 확인 필요)
       case let .routeAction(_, action: .hotKeyword(.showKeywordNewsList(keyword, newsItems))):
         state.routes.push(.newCard(.init(routes: [
           .root(

--- a/Projects/Features/Coordinator/NewsCardCoordinator/NewsCardCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/NewsCardCoordinator/NewsCardCoordinatorCore.swift
@@ -19,7 +19,7 @@ public struct NewsCardCoordinatorState: Equatable, IndexedRouterState {
     routes: [Route<NewsCardScreenState>] = [
       .root(
         .newsList(
-          .init(keywordTitle: "하하호호 키워드 이름")
+          .init(keywordTitle: "하하호호 키워드 이름", newsItems: [])
         ),
         embedInNavigationView: true
       )

--- a/Projects/Features/Scene/HotKeywordScene/HotKeyword/HotKeywordCore.swift
+++ b/Projects/Features/Scene/HotKeywordScene/HotKeyword/HotKeywordCore.swift
@@ -10,6 +10,7 @@ import Combine
 import ComposableArchitecture
 import DesignSystem
 import Foundation
+import NewsList
 import Models
 import Services
 
@@ -20,31 +21,35 @@ public struct HotKeywordState: Equatable {
   var isRefresh: Bool = false
   var isFirstLoading: Bool = true
   var toastMessage: String?
-
+  
   public init() { }
 }
 
 public enum HotKeywordAction: Equatable {
   // MARK: - User Action
   case pullToRefresh
-  case hotKeywordCircleTapped
-
+  case hotKeywordCircleTapped(String)
+  
   // MARK: - Inner Business Action
   case _viewWillAppear
   case _fetchData
   case _reloadData(HotKeywordDTO)
   case _showAnimation
+  case _fetchKeywordShorts(String)
   case _presentToast(String)
   case _hideToast
-
+  
   // MARK: - Inner SetState Action
   case _setToastMessage(String?)
   case _setSubTitleText(String?)
   case _setHotKeywordList([String])
   case _setHotKeywordPointList
-  
   case _setIsRefresh(Bool)
   case _setIsFirstLoading(Bool)
+  case _convertNewsItemsFromNewsCardsDTO([NewsCardsResponseDTO], String)
+  
+  // MARK: - Child Action
+  case showKeywordNewsList(String, IdentifiedArrayOf<NewsCardState>)
 }
 
 public struct HotKeywordEnvironment {
@@ -63,7 +68,7 @@ public struct HotKeywordEnvironment {
 public let hotKeywordReducer = Reducer.combine([
   Reducer<HotKeywordState, HotKeywordAction, HotKeywordEnvironment> { state, action, env in
     struct SetHotKeywordToastCancelID: Hashable {}
-
+    
     switch action {
     case .pullToRefresh:
       return .concatenate([
@@ -71,12 +76,18 @@ public let hotKeywordReducer = Reducer.combine([
         Effect(value: ._setIsRefresh(true))
       ])
       
+    case let .hotKeywordCircleTapped(keyword):
+      guard keyword.isEmpty == false else {
+        return .none
+      }
+      return Effect(value: ._fetchKeywordShorts(keyword))
+      
     case ._viewWillAppear:
       return .concatenate([
         Effect(value: ._setIsFirstLoading(false)),
         Effect(value: ._showAnimation)
       ])
-
+      
     case ._fetchData:
       return env.hotKeywordService.fetchHotKeyword()
         .catchToEffect()
@@ -91,9 +102,9 @@ public let hotKeywordReducer = Reducer.combine([
           }
         }
         .eraseToEffect()
-
+      
     case let ._reloadData(hotKeywordDTO):
-            
+      
       return .concatenate([
         Effect(value: ._setSubTitleText(hotKeywordDTO.createdAt)),
         Effect(value: ._setHotKeywordList(hotKeywordDTO.ranking)),
@@ -127,6 +138,20 @@ public let hotKeywordReducer = Reducer.combine([
       )
       return .none
       
+    case let ._fetchKeywordShorts(keyword):
+      return env.hotKeywordService.fetchKeywordShorts(keyword)
+        .catchToEffect()
+        .flatMapLatest { result -> Effect<HotKeywordAction, Never> in
+          switch result {
+          case let .success(newsCardsResponseDTO):
+            return Effect(value: ._convertNewsItemsFromNewsCardsDTO(newsCardsResponseDTO, keyword))
+            
+          case .failure:
+            return Effect(value: ._presentToast("인터넷 연결 상태가 불안정합니다."))
+          }
+        }
+        .eraseToEffect()
+      
     case let ._presentToast(toastMessage):
       return .concatenate([
         Effect(value: ._setToastMessage(toastMessage)),
@@ -143,7 +168,7 @@ public let hotKeywordReducer = Reducer.combine([
     case let ._setToastMessage(toastMessage):
       state.toastMessage = toastMessage
       return .none
-
+      
     case let ._setIsRefresh(isRefresh):
       state.isRefresh = isRefresh
       return .none
@@ -152,7 +177,15 @@ public let hotKeywordReducer = Reducer.combine([
       state.isFirstLoading = isFirstLoading
       return .none
       
-    case .hotKeywordCircleTapped:
+    case let ._convertNewsItemsFromNewsCardsDTO(responseDTO, keyword):
+      let keyword = "#\(keyword)"
+      var newsItems: IdentifiedArrayOf<NewsCardState> = []
+      responseDTO.forEach { response in
+        newsItems.append(NewsCardState(newsCardsResponseDTO: response))
+      }
+      return Effect(value: .showKeywordNewsList(keyword, newsItems))
+      
+    case let .showKeywordNewsList(keyword, newsItems):
       return .none
     }
   }

--- a/Projects/Features/Scene/HotKeywordScene/HotKeyword/HotKeywordView.swift
+++ b/Projects/Features/Scene/HotKeywordScene/HotKeyword/HotKeywordView.swift
@@ -55,7 +55,11 @@ public struct HotKeywordView: View {
         viewStore.send(.pullToRefresh)
       }
       .onAppear {
-        viewStore.send(._fetchData)
+        if viewStore.isFirstLoading {
+          viewStore.send(._fetchData)
+        } else {
+          offset = viewStore.currentOffset
+        }
       }
       .onChange(of: viewStore.isFirstLoading) { isFirstLoading in
         if isFirstLoading == false {
@@ -113,7 +117,14 @@ public struct HotKeywordView: View {
                     geometryHeight: geometry.size.height,
                     pointX: hotKeywordPoint.x * geometry.size.width,
                     offset: $offset,
-                    action: { viewStore.send(.hotKeywordCircleTapped(hotKeywordPoint.keyword)) }
+                    action: { viewStore
+                      .send(
+                        .hotKeywordCircleTapped(
+                          hotKeywordPoint.keyword,
+                          currentOffset: offset + screenWidth/4
+                        )
+                      )
+                    }
                   )
                   .offset(
                     x: hotKeywordPoint.x * geometry.size.width,

--- a/Projects/Features/Scene/HotKeywordScene/HotKeyword/HotKeywordView.swift
+++ b/Projects/Features/Scene/HotKeywordScene/HotKeyword/HotKeywordView.swift
@@ -105,12 +105,22 @@ public struct HotKeywordView: View {
             HStack {
               scrollObservableView
                 .id(leadingID)
-              
-              BubbleChartView(
-                offset: $offset,
-                hotKeywordPointList: viewStore.hotKeywordPointList,
-                action: { viewStore.send(.hotKeywordCircleTapped) }
-              )
+          
+              GeometryReader { geometry in
+                ForEach(viewStore.hotKeywordPointList.pointList, id: \.self) { hotKeywordPoint in
+                  BubbleView(
+                    hotKeywordPoint: hotKeywordPoint,
+                    geometryHeight: geometry.size.height,
+                    pointX: hotKeywordPoint.x * geometry.size.width,
+                    offset: $offset,
+                    action: { viewStore.send(.hotKeywordCircleTapped(hotKeywordPoint.keyword)) }
+                  )
+                  .offset(
+                    x: hotKeywordPoint.x * geometry.size.width,
+                    y: hotKeywordPoint.y * geometry.size.height
+                  )
+                }
+              }
               .frame(
                 width: geometry.size.height * 1.5,
                 height: geometry.size.height
@@ -133,33 +143,6 @@ public struct HotKeywordView: View {
               proxy.scrollTo(leadingID, anchor: .topLeading)
             }
           }
-        }
-      }
-    }
-  }
-}
-
-// MARK: - BubbleChartView
-extension HotKeywordView {
-  private struct BubbleChartView: View {
-    @Binding var offset: CGFloat
-    var hotKeywordPointList: HotKeywordPointList
-    var action: () -> Void
-
-    var body: some View {
-      GeometryReader { geometry in
-        ForEach(hotKeywordPointList.pointList, id: \.self) { hotKeywordPoint in
-          BubbleView(
-            hotKeywordPoint: hotKeywordPoint,
-            geometryHeight: geometry.size.height,
-            pointX: hotKeywordPoint.x * geometry.size.width,
-            offset: $offset,
-            action: action
-          )
-          .offset(
-            x: hotKeywordPoint.x * geometry.size.width,
-            y: hotKeywordPoint.y * geometry.size.height
-          )
         }
       }
     }

--- a/Projects/Features/Scene/NewsCardScene/NewsList/NewsCard/NewsCardCore.swift
+++ b/Projects/Features/Scene/NewsCardScene/NewsList/NewsCard/NewsCardCore.swift
@@ -9,6 +9,7 @@
 import Combine
 import ComposableArchitecture
 import Foundation
+import Models
 import Web
 
 public struct News: Equatable, Identifiable {
@@ -52,6 +53,27 @@ public struct NewsCardState: Equatable, Identifiable {
   )
   
   var web: WebState = WebState(webAddress: "https://naver.com")
+  
+  // FIXME: to.상희 hotKeyword랑 연동하기 위한 중간다리 임시로 만들어두었습니다. 확인 부탁드려요!
+  public init(id: Int, news: News, web: WebState) {
+    self.id = id
+    self.news = news
+    self.web = web
+  }
+  
+  public init(newsCardsResponseDTO: NewsCardsResponseDTO) {
+    self.id = newsCardsResponseDTO.id
+    self.news = News(
+      id: newsCardsResponseDTO.id,
+      title: newsCardsResponseDTO.keywords,
+      thumbnailImageUrl: nil,
+      newsLink: "https://naver.com",
+      press: "매일경제",
+      writtenDateTime: newsCardsResponseDTO.crawledDateTime,
+      type: newsCardsResponseDTO.category
+    )
+    self.web = WebState(webAddress: "https://naver.com")
+  }
 }
 
 public enum NewsCardAction: Equatable {

--- a/Projects/Features/Scene/NewsCardScene/NewsList/NewsListCore.swift
+++ b/Projects/Features/Scene/NewsCardScene/NewsList/NewsListCore.swift
@@ -14,8 +14,9 @@ public struct NewsListState: Equatable {
   var keywordTitle: String
   var newsItems: IdentifiedArrayOf<NewsCardState> = []
   
-  public init(keywordTitle: String) {
-    self.keywordTitle = "#자위대 호위함 #사카이 료 (Sakai Ryo) #이스턴 엔데버23 #부산항 #자위대 호위함 #사카이 료 (Sakai Ryo) #이스턴 엔데버23 #부산항"
+  public init(keywordTitle: String, newsItems: IdentifiedArrayOf<NewsCardState>) {
+    self.keywordTitle = keywordTitle
+    self.newsItems = newsItems
   }
 }
 
@@ -60,6 +61,7 @@ public let newsListReducer = Reducer.combine([
       ])
       
     case ._onAppear:
+      /* 임시 데이터 안들어가게 잠시 주석해놨습니다
       state.newsItems = [
         NewsCardState(
           id: 0,
@@ -134,6 +136,7 @@ public let newsListReducer = Reducer.combine([
           )
         )
       ]
+       */
       return .none
       
     case ._willDisappear:

--- a/Projects/Features/Scene/TabBarScene/TabBar/TabBarCore.swift
+++ b/Projects/Features/Scene/TabBarScene/TabBar/TabBarCore.swift
@@ -141,7 +141,6 @@ public let tabBarReducer = Reducer<
     switch action {
     case let .tabSelected(tab):
       state.selectedTab = tab
-      // lina-TODO: 코드 정리(이게 최선인지)
       if tab == .hotKeyword {
         return Effect(value: .hotKeyword(.routeAction(0, action: .hotKeyword(._viewWillAppear))))
       }


### PR DESCRIPTION
## Task
- 핫 키워드 눌렀을때 뉴스 목록 화면 나오는 기능 수정

## 참고
@AhnSangHee 상희 작업하는 코드에 제꺼 들어가야해서 어떻게 하실지 몰라서 제가 대략 돌아가게만 해뒀는데 확인 후 수정 부탁드립니다~😉
추가로 아래와 같은 이슈들이 있는데
**1. 탭바 노출 2. 돌아왔을때 핫 화면 리프레시 3. 해당 화면 들어갔다 나왔다 하면 보라색 UI 경고 발생** \
뉴스 리스트쪽이 어떻게 되어있는지 몰라서 원인이 파악이 어렵네요! 확인 요청드려욥! 

## 스크린샷
![Jun-28-2023 00-58-12](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/49546979/97ad2e87-addf-42d8-93dd-96abfaa1f937)
