### PR TITLE
기능: 로딩 인디케이터 연결

### DIFF
--- a/Projects/Features/Scene/MainScene/Main/MainView.swift
+++ b/Projects/Features/Scene/MainScene/Main/MainView.swift
@@ -57,6 +57,7 @@ public struct MainView: View {
         
         Spacer()
       }
+      .loading(!viewStore.fetchIds.isEmpty)
       .onAppear {
         viewStore.send(._setNewsCardSize(UIScreen.main.bounds.size))
         viewStore.send(._viewWillAppear)


### PR DESCRIPTION
## Task
- 로딩 인디케이터 작업
- close #83 

## 참고
- isLoading 프로퍼티가 아닌 현재 fetch 중인 액션의 개수로 판단했습니다...
- 바텀 시트 카테고리 변경 후 아웃오브인덱스 에러 는 수정 중에 있습니다..

## 설명
fetch 액션 전에 fetchIds에 fetchId을 다 삽입합니다..
```swift

enum FetchID: Hashable, CaseIterable {
  case _fetchCategories
  case _fetchNewsCards
}

// MainState
var fetchIds: Set<FetchID> = []

// MainAction
case ._viewWillAppear:
      FetchID.allCases.forEach { state.fetchIds.insert($0) }
      return Effect.merge(
        Effect(value: ._fetchCategories),
        Effect(value: ._fetchNewsCards(.initial))
      )
```

set 액션전에 fetchIds의 값을 삭제합니다.
```swift
case let ._setCategories(result):
      state.fetchIds.remove(FetchID._fetchCategories)
      switch result {
      case let .success(categories):
        state.categories = categories
        return .none
        
      case .failure:
        return .none
      }
      
case let ._setNewsCards(result, fetchType):
     state.fetchIds.remove(FetchID._fetchNewsCards)
     switch result {
     case let .success(newsCards):
       return handleNewsCardsResponse(&state, source: newsCards, fetchType: fetchType)
     
     case .failure:
       return .none
     }
```

뷰랑은 fetchIds로 판단합니다. 
```swift
.loading(!viewStore.fetchIds.isEmpty)
```
