### PR TITLE
버그: 카테고리 변경 로직 시퀀스 보장

### DIFF
--- a/Projects/Features/Scene/MainScene/Main/MainCore.swift
+++ b/Projects/Features/Scene/MainScene/Main/MainCore.swift
@@ -51,6 +51,7 @@ public enum MainAction {
   case _fetchNewsCards(FetchType)
   
   // MARK: - Inner SetState Action
+  case _initialize
   case _setNewsCardSize(CGSize)
   case _setCategories(Result<[CategoryType], Error>)
   case _setNewsCards(Result<[NewsCard], Error>, FetchType)
@@ -116,11 +117,13 @@ public let mainReducer = Reducer.combine([
       )
       
     case ._categoriesIsUpdated:
-      state.newsCardScrollState = nil
-      state.saveGuideState = nil
-      state.cursorPage = 0
-      state.cursorDate = .now
-      return Effect(value: ._viewWillAppear)
+      return Effect.concatenate(
+        Effect(value: ._initialize),
+        Effect(value: ._viewWillAppear)
+          .delay(for: .milliseconds(500), scheduler: env.mainQueue)
+          .eraseToEffect()
+      )
+      
       
     case ._fetchCategories:
       return env.categoryService.getAllCategories()
@@ -138,6 +141,15 @@ public let mainReducer = Reducer.combine([
       .map { MainAction._setNewsCards($0, fetchType) }
       .eraseToEffect()
       
+    case ._initialize:
+      state.fetchIds = []
+      state.categories = []
+      state.newsCardScrollState = nil
+      state.cursorPage = 0
+      state.cursorDate = .now
+      state.saveGuideState = nil
+      return .none
+    
     case let ._setNewsCardSize(screenSize):
       state.newsCardLayout = buildNewsCardLayout(screenSize: screenSize)
       return .none


### PR DESCRIPTION
## Task
- #85 

## 참고
일단.. `newsScrollState`를 `nil`하고 적당한 0.5초 후에 `fetch` 작업이 실행되게 했습니다.....
```swift
case ._categoriesIsUpdated:
      return Effect.concatenate(
        Effect(value: ._initialize),
        Effect(value: ._viewWillAppear)
          .delay(for: .milliseconds(500), scheduler: env.mainQueue)
          .eraseToEffect()
      )
```

## 스크린샷
![Simulator Screen Recording - iPhone 13 mini - 2023-06-28 at 10 59 00](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/48887389/8d9a65a5-128a-4520-8cfd-af4e445e12dc)
