### PR TITLE
기능: 뉴스 카드 선택시 뉴스 리스트로 이동하는 로직 구현

### DIFF
--- a/Projects/Core/Models/Network/NewsCard/RequestDTO/NewsRequestDTO.swift
+++ b/Projects/Core/Models/Network/NewsCard/RequestDTO/NewsRequestDTO.swift
@@ -1,0 +1,30 @@
+//
+//  NewsRequestDTO.swift
+//  Models
+//
+//  Created by 김영균 on 2023/06/28.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import Foundation
+
+public struct NewsRequestDTO: Encodable {
+  public let cursorWrittenDateTime: String
+  public let size: Int
+  public let pivot: Pivot
+  
+  public enum Pivot: String, Encodable {
+    case DESC
+    case ASC
+  }
+  
+  public init(
+    cursorWrittenDateTime: String = "",
+    size: Int = 10,
+    pivot: Pivot = .DESC
+  ) {
+    self.cursorWrittenDateTime = cursorWrittenDateTime
+    self.size = size
+    self.pivot = pivot
+  }
+}

--- a/Projects/Core/Models/Network/NewsCard/ResponseDTO/NewsResponseDTO.swift
+++ b/Projects/Core/Models/Network/NewsCard/ResponseDTO/NewsResponseDTO.swift
@@ -1,0 +1,19 @@
+//
+//  NewsResponseDTO.swift
+//  Models
+//
+//  Created by 김영균 on 2023/06/28.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import Foundation
+
+public struct NewsResponseDTO: Decodable {
+  public let id: Int
+  public let title: String
+  public let thumbnailImageUrl: String
+  public let newsLink: String
+  public let press: String
+  public let writtenDateTime: String
+  public let type: String
+}

--- a/Projects/Core/Services/NewsCard/NewsCardAPI.swift
+++ b/Projects/Core/Services/NewsCard/NewsCardAPI.swift
@@ -13,6 +13,7 @@ import Models
 public enum NewsCardAPI {
   case getAllNewsCards(Date, Int, Int)
   case saveNewsCard(Int)
+  case getNewsCard(Int)
 }
 
 extension NewsCardAPI: TargetType {
@@ -27,6 +28,9 @@ extension NewsCardAPI: TargetType {
     
     case .saveNewsCard:
       return "/member/news-card"
+      
+    case let .getNewsCard(newsId):
+      return "/news-card/\(newsId)"
     }
   }
   
@@ -37,6 +41,9 @@ extension NewsCardAPI: TargetType {
       
     case .saveNewsCard:
       return .post
+      
+    case .getNewsCard:
+      return .get
     }
   }
   
@@ -56,6 +63,12 @@ extension NewsCardAPI: TargetType {
     case let .saveNewsCard(newsCardId):
       let requestDTO = SaveNewsCardRequestDTO(newsCardId: newsCardId)
       return .requestJSONEncodable(requestDTO)
+      
+    case .getNewsCard:
+      return .requestParameters(
+        parameters: NewsRequestDTO.init().toDictionary,
+        encoding: .queryString
+      )
     }
   }
   

--- a/Projects/Core/Services/NewsCard/NewsCardService.swift
+++ b/Projects/Core/Services/NewsCard/NewsCardService.swift
@@ -24,6 +24,7 @@ public struct NewsCardService {
   ) -> Effect<[NewsCard], Error>
   
   public var saveNewsCard: (_ newsCardId: Int) -> Effect<VoidResponse?, Error>
+  public var getNewsCard: (_ newsCardId: Int) -> Effect<[NewsResponseDTO], Error>
 }
 
 extension NewsCardService {
@@ -46,6 +47,16 @@ extension NewsCardService {
           NewsCardAPI.saveNewsCard(newsCardId),
           type: VoidResponse.self
         )
+        .eraseToEffect()
+    },
+    getNewsCard: { newsCardId in
+      return Provider<NewsCardAPI>
+        .init()
+        .request(
+          NewsCardAPI.getNewsCard(newsCardId),
+          type: [NewsResponseDTO].self
+        )
+        .compactMap { $0 }
         .eraseToEffect()
     }
   )

--- a/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
@@ -10,6 +10,7 @@ import Combine
 import ComposableArchitecture
 import Foundation
 import Main
+import NewsCardCoordinator
 import Services
 import TCACoordinators
 
@@ -70,6 +71,23 @@ public let mainCoordinatorReducer: Reducer<
   .withRouteReducer(
     Reducer { state, action, env in
       switch action {
+      case let .routeAction(
+        _, action: .main(
+          .newsCardScroll(
+            .newsCard(
+              id: _, action: ._navigateNewsList(id)
+            )
+          )
+        )
+      ):
+        // TODO: id를 건네줘야한다.
+        state.routes.push(.newsCard(.init()))
+        return .none
+        
+      case .routeAction(_, action: .newsCard(.routeAction(_, action: .newsList(.backButtonTapped)))):
+        state.routes.pop()
+        return .none
+        
       default: return .none
       }
     }

--- a/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorView.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorView.swift
@@ -8,6 +8,7 @@
 
 import ComposableArchitecture
 import Main
+import NewsCardCoordinator
 import SwiftUI
 import TCACoordinators
 
@@ -25,6 +26,11 @@ public struct MainCoordinatorView: View {
           state: /MainScreenState.main,
           action: MainScreenAction.main,
           then: MainView.init
+        )
+        CaseLet(
+          state: /MainScreenState.newsCard,
+          action: MainScreenAction.newsCard,
+          then: NewsCardCoordinatorView.init
         )
       }
     }

--- a/Projects/Features/Coordinator/MainCoordinator/MainScreenCore.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainScreenCore.swift
@@ -10,15 +10,18 @@ import Combine
 import ComposableArchitecture
 import Foundation
 import Main
+import NewsCardCoordinator
 import Services
 import TCACoordinators
 
 public enum MainScreenState: Equatable {
   case main(MainState)
+  case newsCard(NewsCardCoordinatorState)
 }
 
 public enum MainScreenAction {
   case main(MainAction)
+  case newsCard(NewsCardCoordinatorAction)
 }
 
 internal struct MainScreenEnvironment {
@@ -56,6 +59,14 @@ internal let mainScreenReducer = Reducer<
           newscardService: $0.newsCardService,
           categoryService: $0.categoryService
         )
+      }
+    ),
+  newsCardCoordinatorReducer
+    .pullback(
+      state: /MainScreenState.newsCard,
+      action: /MainScreenAction.newsCard,
+      environment: { _ in
+        NewsCardCoordinatorEnvironment()
       }
     )
 ])

--- a/Projects/Features/Coordinator/Project.swift
+++ b/Projects/Features/Coordinator/Project.swift
@@ -59,6 +59,7 @@ let project = Project.make(
       bundleId: "com.mashup.seeYouAgain.mainCoordinator",
       sources: ["MainCoordinator/**"],
       dependencies: [
+				.target(name: "NewsCardCoordinator"),
         .project(target: "Main", path: .relativeToRoot("Projects/Features/Scene")),
         .externalsrt("TCA"),
         .externalsrt("TCACoordinators"),

--- a/Projects/Features/Scene/MainScene/Main/MainCore.swift
+++ b/Projects/Features/Scene/MainScene/Main/MainCore.swift
@@ -109,6 +109,7 @@ public let mainReducer = Reducer.combine([
   Reducer<MainState, MainAction, MainEnvironment> { state, action, env in
     switch action {
     case ._viewWillAppear:
+      guard state.newsCardScrollState == nil, state.saveGuideState == nil else { return .none }
       FetchID.allCases.forEach { state.fetchIds.insert($0) }
       return Effect.merge(
         Effect(value: ._fetchCategories),

--- a/Projects/Features/Scene/MainScene/Main/NewsCard/Components/LetterPaper.swift
+++ b/Projects/Features/Scene/MainScene/Main/NewsCard/Components/LetterPaper.swift
@@ -89,7 +89,7 @@ private struct Keywords: View {
   
   fileprivate var body: some View {
     VStack(spacing: 12) {
-      ForEach(keywords.indices, id: \.self) { index in
+      ForEach(0..<4, id: \.self) { index in
         HStack {
           Text("#\(keywords[index])")
             .font(.b20)

--- a/Projects/Features/Scene/MainScene/Main/NewsCard/Components/LetterPaper.swift
+++ b/Projects/Features/Scene/MainScene/Main/NewsCard/Components/LetterPaper.swift
@@ -89,7 +89,7 @@ private struct Keywords: View {
   
   fileprivate var body: some View {
     VStack(spacing: 12) {
-      ForEach(0..<4, id: \.self) { index in
+      ForEach(0..<min(4, keywords.count), id: \.self) { index in
         HStack {
           Text("#\(keywords[index])")
             .font(.b20)

--- a/Projects/Features/Scene/MainScene/Main/NewsCard/NewsCardCore.swift
+++ b/Projects/Features/Scene/MainScene/Main/NewsCard/NewsCardCore.swift
@@ -23,8 +23,10 @@ public struct NewsCardState: Equatable, Identifiable {
 public enum NewsCardAction {
   // MARK: User Action
   case dragGestureEnded(CGSize)
+  case newsCardTapped
   
   // MARK: - Inner Business Action
+  case _navigateNewsList(Int)
   case _saveNewsCard
   case _handleSaveNewsCardResponse(Result<VoidResponse?, Error>)
   
@@ -51,6 +53,9 @@ public let newsCardReducer = Reducer<
       return Effect(value: ._saveNewsCard)
     }
     return .none
+    
+  case .newsCardTapped:
+    return Effect(value: ._navigateNewsList(state.newsCard.id))
     
   case ._saveNewsCard:
     return env.newsCardService.saveNewsCard(state.newsCard.id)

--- a/Projects/Features/Scene/MainScene/Main/NewsCard/NewsCardView.swift
+++ b/Projects/Features/Scene/MainScene/Main/NewsCard/NewsCardView.swift
@@ -56,6 +56,9 @@ struct NewsCardView: View {
             deviceRatio: viewStore.layout.ratio
           )
         }
+        .onTapGesture {
+          viewStore.send(.newsCardTapped)
+        }
         .gesture(
           DragGesture()
             .onEnded { viewStore.send(.dragGestureEnded($0.translation)) }

--- a/Projects/Features/Scene/TabBarScene/TabBar/TabBarCore.swift
+++ b/Projects/Features/Scene/TabBarScene/TabBar/TabBarCore.swift
@@ -9,7 +9,6 @@
 import ComposableArchitecture
 import Foundation
 import HotKeywordCoordinator
-import Main
 import MainCoordinator
 import MyPageCoordinator
 import Services
@@ -196,6 +195,12 @@ public let tabBarReducer = Reducer<
       case .failure:
         return Effect(value: ._presentToast("인터넷이 불안정해서 저장되지 못했어요."))
       }
+      
+    case .main(.routeAction(_, action: .main(.newsCardScroll(.newsCard(id: _, action: ._navigateNewsList))))):
+      return Effect(value: ._setTabHiddenStatus(true))
+    
+    case .main(.routeAction(_, action: .newsCard(.routeAction(_, action: .newsList(.backButtonTapped))))):
+      return Effect(value: ._setTabHiddenStatus(false))
       
     case .myPage(.routeAction(_, action: .myPage(.settingButtonTapped))):
       return Effect(value: ._setTabHiddenStatus(true))


### PR DESCRIPTION
## Task
- 뉴스 카드 선택하면 뉴스 리스트로 이동하게 했습니다.
- close #87 

## 참고
- 상희누나가 NewsCardCoordinator로 뉴스 아이디를 넘겨주면 된다고하셔서 일단 넘겨주는거 전까지 구현했습니다. 

## 스크린샷
![Simulator Screen Recording - iPhone 13 mini - 2023-06-29 at 10 29 50](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/48887389/23465bc7-c825-43b8-97d1-7f298f2dd823)
