### PR TITLE
기능: 저장 후 다음 뉴스카드로 자동 스크롤 구현 

### DIFF
--- a/Projects/Core/Models/Network/NewsCard/RequestDTO/SaveNewsCardRequestDTO.swift
+++ b/Projects/Core/Models/Network/NewsCard/RequestDTO/SaveNewsCardRequestDTO.swift
@@ -9,9 +9,13 @@
 import Foundation
 
 public struct SaveNewsCardRequestDTO: Encodable {
-  public var newsCardId: Int
+  public var newsCardID: Int
   
-  public init(newsCardId: Int) {
-    self.newsCardId = newsCardId
+  public init(newsCardID: Int) {
+    self.newsCardID = newsCardID
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case newsCardID = "newsCardId"
   }
 }

--- a/Projects/Core/Models/Network/NewsCard/ResponseDTO/NewsResponseDTO.swift
+++ b/Projects/Core/Models/Network/NewsCard/ResponseDTO/NewsResponseDTO.swift
@@ -11,9 +11,19 @@ import Foundation
 public struct NewsResponseDTO: Decodable {
   public let id: Int
   public let title: String
-  public let thumbnailImageUrl: String
+  public let thumbnailImageURL: String
   public let newsLink: String
   public let press: String
   public let writtenDateTime: String
   public let type: String
+  
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case thumbnailImageURL = "thumbnailImageUrl"
+    case newsLink
+    case press
+    case writtenDateTime
+    case type
+  }
 }

--- a/Projects/Core/Services/NewsCard/NewsCardAPI.swift
+++ b/Projects/Core/Services/NewsCard/NewsCardAPI.swift
@@ -60,8 +60,8 @@ extension NewsCardAPI: TargetType {
         encoding: .queryString
       )
       
-    case let .saveNewsCard(newsCardId):
-      let requestDTO = SaveNewsCardRequestDTO(newsCardId: newsCardId)
+    case let .saveNewsCard(newsCardID):
+      let requestDTO = SaveNewsCardRequestDTO(newsCardID: newsCardID)
       return .requestJSONEncodable(requestDTO)
       
     case .getNewsCard:

--- a/Projects/Features/Scene/MainScene/Main/MainCore.swift
+++ b/Projects/Features/Scene/MainScene/Main/MainCore.swift
@@ -93,7 +93,12 @@ public let mainReducer = Reducer.combine([
     .pullback(
       state: \.newsCardScrollState,
       action: /MainAction.newsCardScroll,
-      environment: { NewsCardScrollEnvironmnet(newsCardService: $0.newsCardService) }
+      environment: {
+        NewsCardScrollEnvironmnet(
+          mainQueue: $0.mainQueue,
+          newsCardService: $0.newsCardService
+        )
+      }
     ),
   saveGuideReducer
     .optional()
@@ -124,7 +129,6 @@ public let mainReducer = Reducer.combine([
           .delay(for: .milliseconds(500), scheduler: env.mainQueue)
           .eraseToEffect()
       )
-      
       
     case ._fetchCategories:
       return env.categoryService.getAllCategories()

--- a/Projects/Features/Scene/MainScene/Main/NewsCard/NewsCardScrollCore.swift
+++ b/Projects/Features/Scene/MainScene/Main/NewsCard/NewsCardScrollCore.swift
@@ -179,7 +179,7 @@ public let newsCardScrollReducer = Reducer<
       concatenateNewsCards(&state, source: newsCards)
       return .none
       
-    case .newsCard(id: _, action: ._saveNewsCard):
+    case .newsCard(id: _, action: ._handleSaveNewsCardResponse(.success)):
       let nextScrollIndex = state.currentScrollIndex + 1
       let newsCardCount = state.newsCards.count
       // 다음 카드가 없으면 자동으로 넘어가지 않는다.


### PR DESCRIPTION
## Task
- 저장 후 다음 뉴스카드로 자동 스크롤 구현해봤습니다,, 
- close #91 

## 참고
-  더 좋은 방법이 있을 것 같은데 일단 자연스럽게 넘어가는 것을 위해서 drag action을 계속해서 실행시켰습니다,,

## 스크린샷
![Simulator Screen Recording - iPhone 13 mini - 2023-06-29 at 11 25 56](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/48887389/f8ca592f-66e3-48cd-83f7-dbba6e6cdbaa)
