### PR TITLE
리팩터: 핫 키워드에서 뉴스 리스트 들어가는 진입점, 앱 코디네이터로 변경

### DIFF
--- a/Projects/Features/Coordinator/AppCoordinator/AppCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/AppCoordinator/AppCoordinatorCore.swift
@@ -136,6 +136,30 @@ public let appCoordinatorReducer: Reducer<
         return .none
         
       case let .routeAction(
+        _, action: .tabBar(
+          .hotKeyword(
+            .routeAction(
+              _, action: .hotKeyword(
+                .showKeywordNewsList(keyword)
+              )
+            )
+          )
+        )
+      ):
+        // TODO: 상희야 키워드 넣어놓았다
+        state.routes.push(.newsCard(
+          .init(routes: [
+            .root(
+              .newsList(
+                .init(keywordTitle: keyword)
+              ),
+              embedInNavigationView: true
+            )
+          ])
+        ))
+        return .none
+        
+      case let .routeAction(
         _,
         action: .tabBar(
           .myPage(

--- a/Projects/Features/Coordinator/HotKeywordCoordinator/HotKeywordCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/HotKeywordCoordinator/HotKeywordCoordinatorCore.swift
@@ -59,21 +59,6 @@ public let hotKeywordCoordinatorReducer: Reducer<
   .withRouteReducer(
     Reducer { state, action, env in
       switch action {
-//      case let .routeAction(_, action: .hotKeyword(.showKeywordNewsList(keyword))):
-//        state.routes.push(.newCard(.init(routes: [
-//          .root(
-//            .newsList(
-//              .init(keywordTitle: keyword)
-//            ),
-//            embedInNavigationView: true
-//          )
-//        ])))
-//        return .none
-//
-//      case .routeAction(_, action: .newCard(.routeAction(_, action: .newsList(.backButtonTapped)))):
-//        state.routes.pop()
-//        return .none
-//
       default: return .none
       }
     }

--- a/Projects/Features/Coordinator/HotKeywordCoordinator/HotKeywordCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/HotKeywordCoordinator/HotKeywordCoordinatorCore.swift
@@ -8,7 +8,6 @@
 
 import ComposableArchitecture
 import HotKeyword
-import NewsCardCoordinator
 import Services
 import SwiftUI
 import TCACoordinators
@@ -60,21 +59,21 @@ public let hotKeywordCoordinatorReducer: Reducer<
   .withRouteReducer(
     Reducer { state, action, env in
       switch action {
-      case let .routeAction(_, action: .hotKeyword(.showKeywordNewsList(keyword))):
-        state.routes.push(.newCard(.init(routes: [
-          .root(
-            .newsList(
-              .init(keywordTitle: keyword)
-            ),
-            embedInNavigationView: true
-          )
-        ])))
-        return .none
-
-      case .routeAction(_, action: .newCard(.routeAction(_, action: .newsList(.backButtonTapped)))):
-        state.routes.pop()
-        return .none
-        
+//      case let .routeAction(_, action: .hotKeyword(.showKeywordNewsList(keyword))):
+//        state.routes.push(.newCard(.init(routes: [
+//          .root(
+//            .newsList(
+//              .init(keywordTitle: keyword)
+//            ),
+//            embedInNavigationView: true
+//          )
+//        ])))
+//        return .none
+//
+//      case .routeAction(_, action: .newCard(.routeAction(_, action: .newsList(.backButtonTapped)))):
+//        state.routes.pop()
+//        return .none
+//
       default: return .none
       }
     }

--- a/Projects/Features/Coordinator/HotKeywordCoordinator/HotKeywordCoordinatorView.swift
+++ b/Projects/Features/Coordinator/HotKeywordCoordinator/HotKeywordCoordinatorView.swift
@@ -8,7 +8,6 @@
 
 import ComposableArchitecture
 import HotKeyword
-import NewsCardCoordinator
 import SwiftUI
 import TCACoordinators
 
@@ -26,11 +25,6 @@ public struct HotKeywordCoordinatorView: View {
           state: /HotKeywordScreenState.hotKeyword,
           action: HotKeywordScreenAction.hotKeyword,
           then: HotKeywordView.init
-        )
-        CaseLet(
-          state: /HotKeywordScreenState.newCard,
-          action: HotKeywordScreenAction.newCard,
-          then: NewsCardCoordinatorView.init
         )
       }
     }

--- a/Projects/Features/Coordinator/HotKeywordCoordinator/HotKeywordScreenCore.swift
+++ b/Projects/Features/Coordinator/HotKeywordCoordinator/HotKeywordScreenCore.swift
@@ -9,18 +9,15 @@
 import ComposableArchitecture
 import Dispatch
 import HotKeyword
-import NewsCardCoordinator
 import Services
 import TCACoordinators
 
 public enum HotKeywordScreenState: Equatable {
   case hotKeyword(HotKeywordState)
-  case newCard(NewsCardCoordinatorState)
 }
 
 public enum HotKeywordScreenAction: Equatable {
   case hotKeyword(HotKeywordAction)
-  case newCard(NewsCardCoordinatorAction)
 }
 
 internal struct HotKeywordScreenEnvironment {
@@ -50,14 +47,6 @@ internal let hotKeywordScreenReducer = Reducer<
           mainQueue: $0.mainQueue,
           hotKeywordService: $0.hotKeywordService
         )
-      }
-    ),
-  newsCardCoordinatorReducer
-    .pullback(
-      state: /HotKeywordScreenState.newCard,
-      action: /HotKeywordScreenAction.newCard,
-      environment: { _ in
-        NewsCardCoordinatorEnvironment()
       }
     ),
 ])

--- a/Projects/Features/Coordinator/Project.swift
+++ b/Projects/Features/Coordinator/Project.swift
@@ -70,7 +70,6 @@ let project = Project.make(
       bundleId: "com.mashup.seeYouAgain.hotKeyword",
       sources: ["HotKeywordCoordinator/**"],
       dependencies: [
-        .target(name: "NewsCardCoordinator"),
         .project(target: "HotKeyword", path: .relativeToRoot("Projects/Features/Scene")),
         .externalsrt("TCA"),
         .externalsrt("TCACoordinators"),

--- a/Projects/Features/Scene/TabBarScene/TabBar/TabBarCore.swift
+++ b/Projects/Features/Scene/TabBarScene/TabBar/TabBarCore.swift
@@ -202,9 +202,6 @@ public let tabBarReducer = Reducer<
     case .hotKeyword(.routeAction(_, action: .hotKeyword(.showKeywordNewsList))):
       return Effect(value: ._setTabHiddenStatus(true))
     
-    case .hotKeyword(.routeAction(_, action: .newCard(.routeAction(_, action: .newsList(.backButtonTapped))))):
-      return Effect(value: ._setTabHiddenStatus(false))
-      
     case .myPage(.routeAction(_, action: .myPage(.settingButtonTapped))):
       return Effect(value: ._setTabHiddenStatus(true))
       


### PR DESCRIPTION
## Task

[핫키워드 화면 구현](https://github.com/mash-up-kr/SeeYouAgain_iOS/issues/76)

## 참고
- 영균이꺼 참고해서 수정했음

## 전달사항
- 나 할 일 끝난듯?