### PR TITLE
버그: Web import 제거 및 오래 간직할 숏스 화면 동작 로직 수정

### DIFF
--- a/Projects/Features/Coordinator/AppCoordinator/AppCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/AppCoordinator/AppCoordinatorCore.swift
@@ -183,6 +183,58 @@ public let appCoordinatorReducer: Reducer<
         state.routes.push(.newsCard(.init()))
         return .none
         
+      case let .routeAction(
+        _,
+        action: .tabBar(
+          .myPage(
+            .routeAction(
+              _,
+              action: .longStorage(
+                .routeAction(
+                  _,
+                  action: .longStorageNewsList(
+                    .shortsNewsItem(
+                      id: id,
+                      action: .cardAction(.cardTapped)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      ):
+        state.routes.push(.newsCard(.init(routes: [.root(.web(.init(webAddress: "https://naver.com")))])))
+        return .none
+        
+      case let .routeAction(
+        _,
+        action: .tabBar(
+          .myPage(
+            .routeAction(
+              _,
+              action: .longStorage(
+                .routeAction(
+                  _,
+                  action: .longStorageNewsList(
+                    .shortsNewsItem(
+                      id: id,
+                      action: .cardAction(.rightButtonTapped)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      ):
+        state.routes.push(.newsCard(.init(routes: [.root(.web(.init(webAddress: "https://naver.com")))])))
+        return .none
+        
+      case .routeAction(_, action: .newsCard(.routeAction(_, action: .web(.backButtonTapped)))):
+        state.routes.pop()
+        return .none
+
       case .routeAction(_, action: .newsCard(.routeAction(_, action: .shortsComplete(.backButtonTapped)))):
         state.routes.pop()
         return Effect(

--- a/Projects/Features/Coordinator/LongStorageCoordinator/LongStorageCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/LongStorageCoordinator/LongStorageCoordinatorCore.swift
@@ -53,28 +53,6 @@ public let longStorageCoordinatorReducer: Reducer<
   .withRouteReducer(
     Reducer { state, action, env in
       switch action {
-      case .routeAction(
-        _,
-        action: .longStorageNewsList(
-          .shortsNewsItem(
-            id: _,
-            action: .cardAction(
-              .rightButtonTapped
-            )
-          )
-        )
-      ):
-        state.routes.push(.web(.init(webAddress: "https://naver.com")))
-        return .none
-        
-      case .routeAction(_, action: .longStorageNewsList(.shortsNewsItem(id: _, action: .cardAction(.cardTapped)))):
-        state.routes.push(.web(.init(webAddress: "https://naver.com")))
-        return .none
-
-      case .routeAction(_, action: .web(.backButtonTapped)):
-        state.routes.pop()
-        return .none
-        
       default: return .none
       }
     }

--- a/Projects/Features/Coordinator/LongStorageCoordinator/LongStorageCoordinatorView.swift
+++ b/Projects/Features/Coordinator/LongStorageCoordinator/LongStorageCoordinatorView.swift
@@ -10,7 +10,6 @@ import ComposableArchitecture
 import LongStorageNewsList
 import SwiftUI
 import TCACoordinators
-import Web
 
 public struct LongStorageCoordinatorView: View {
   private let store: Store<LongStorageCoordinatorState, LongStorageCoordinatorAction>
@@ -26,11 +25,6 @@ public struct LongStorageCoordinatorView: View {
           state: /LongStorageScreenState.longStorageNewsList,
           action: LongStorageScreenAction.longStorageNewsList,
           then: LongStorageNewsListView.init
-        )
-        CaseLet(
-          state: /LongStorageScreenState.web,
-          action: LongStorageScreenAction.web,
-          then: WebView.init
         )
       }
     }

--- a/Projects/Features/Coordinator/LongStorageCoordinator/LongStorageScreenCore.swift
+++ b/Projects/Features/Coordinator/LongStorageCoordinator/LongStorageScreenCore.swift
@@ -10,16 +10,13 @@ import ComposableArchitecture
 import LongStorageNewsList
 import Services
 import TCACoordinators
-import Web
 
 public enum LongStorageScreenState: Equatable {
   case longStorageNewsList(LongStorageNewsListState)
-  case web(WebState)
 }
 
 public enum LongStorageScreenAction: Equatable {
   case longStorageNewsList(LongStorageNewsListAction)
-  case web(WebAction)
 }
 
 internal struct LongStorageScreenEnvironment {
@@ -30,14 +27,6 @@ internal let longStorageScreenReducer = Reducer<
   LongStorageScreenAction,
   LongStorageScreenEnvironment
 >.combine([
-  webReducer
-    .pullback(
-      state: /LongStorageScreenState.web,
-      action: /LongStorageScreenAction.web,
-      environment: { _ in
-        WebEnvironment()
-      }
-    ),
   longStorageNewsListReducer
     .pullback(
       state: /LongStorageScreenState.longStorageNewsList,

--- a/Projects/Features/Coordinator/NewsCardCoordinator/NewsCardCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/NewsCardCoordinator/NewsCardCoordinatorCore.swift
@@ -48,21 +48,9 @@ public let newsCardCoordinatorReducer: Reducer<
   })
   .withRouteReducer(
     Reducer { state, action, env in
-      switch action {
-      case .routeAction(_, action: .newsList(.newsItem(id: _, action: .rightButtonTapped))):
-        state.routes.push(.web(.init(webAddress: "https://naver.com")))
-        return .none
-        
-      case .routeAction(_, action: .newsList(.newsItem(id: _, action: .cardTapped))):
-        state.routes.push(.web(.init(webAddress: "https://naver.com")))
-        return .none
-        
+      switch action {        
       case .routeAction(_, action: .newsList(._willDisappear)):
         state.routes.push(.shortsComplete(.init()))
-        return .none
-        
-      case .routeAction(_, action: .web(.backButtonTapped)):
-        state.routes.pop()
         return .none
 
       default: return .none

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongShortsItem/LongShortsCardCore.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongShortsItem/LongShortsCardCore.swift
@@ -7,7 +7,6 @@
 //
 
 import ComposableArchitecture
-import Web
 
 public struct News: Equatable, Identifiable {
   public let id: Int
@@ -54,8 +53,6 @@ public struct LongShortsCardState: Equatable, Identifiable {
     self.isCardSelectable = isCardSelectable
     self.isSelected = isSelected
   }
-  
-  var web: WebState = WebState(webAddress: "https://naver.com")
 }
 
 public enum LongShortsCardAction: Equatable {

--- a/Projects/Features/Scene/NewsCardScene/NewsList/NewsCard/NewsCardCore.swift
+++ b/Projects/Features/Scene/NewsCardScene/NewsList/NewsCard/NewsCardCore.swift
@@ -10,7 +10,6 @@ import Combine
 import ComposableArchitecture
 import Foundation
 import Models
-import Web
 
 public struct News: Equatable, Identifiable {
   public let id: Int
@@ -51,8 +50,6 @@ public struct NewsCardState: Equatable, Identifiable {
     writtenDateTime: "2023.06.03 04:24",
     type: "경제"
   )
-  
-  var web: WebState = WebState(webAddress: "https://naver.com")
 }
 
 public enum NewsCardAction: Equatable {
@@ -65,7 +62,6 @@ public enum NewsCardAction: Equatable {
   // MARK: - Inner SetState Action
   
   // MARK: - Child Action
-  case web(WebAction)
 }
 
 public struct NewsCardEnvironment {


### PR DESCRIPTION
## Task
- LongStorageCoordinatorCore, View에서 Web을 import 하지 않도록 수정
- 오래 간직할 숏스 화면 > 뉴스 웹페이지로 이동하는 동작을 앱코디네이터코어에서 하도록 수정

## 참고
![CleanShot 2023-07-01 at 00 22 49@2x](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/95578975/b12b9d6a-4d86-4bdc-ba60-9b3772fcb8ed)