### PR TITLE
버그: 뉴스리스트에서 뒤로가기 할 때 탭바가 보이는 버그 수정 

### DIFF
--- a/Projects/Features/Coordinator/AppCoordinator/AppCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/AppCoordinator/AppCoordinatorCore.swift
@@ -30,7 +30,7 @@ public struct AppCoordinatorEnvironment {
   let mainQueue: AnySchedulerOf<DispatchQueue>
   let userDefaultsService: UserDefaultsService
   let appVersionService: AppVersionService
-  let newsCardService: NewsCardService  
+  let newsCardService: NewsCardService
   let categoryService: CategoryService
   let hotKeywordService: HotKeywordService
   let myPageService: MyPageService
@@ -131,23 +131,7 @@ public let appCoordinatorReducer: Reducer<
           )
         )
       ):
-        state.routes.push(
-          .newsCard(
-            .init(
-              routes: [
-                .root(
-                  .newsList(
-                    .init(
-                      shortsId: id,
-                      keywordTitle: keyword
-                    )
-                  ),
-                  embedInNavigationView: true
-                )
-              ]
-            )
-          )
-        )
+        state.routes.push(.newsCard(.init(source: .main, shortsId: id, keywordTitle: keyword)))
         return .none
         
       case let .routeAction(
@@ -161,22 +145,9 @@ public let appCoordinatorReducer: Reducer<
           )
         )
       ):
-        state.routes.push(.newsCard(
-          .init(routes: [
-            .root(
-              .newsList(
-                .init(
-                  source: .hot,
-                  shortsId: 0,
-                  keywordTitle: "#\(keyword)"
-                )
-              ),
-              embedInNavigationView: true
-            )
-          ])
-        ))
+        state.routes.push(.newsCard(.init(source: .hot, shortsId: 0, keywordTitle: "#\(keyword)")))
         return .none
-
+        
       case let .routeAction(
         _,
         action: .tabBar(
@@ -198,19 +169,7 @@ public let appCoordinatorReducer: Reducer<
           )
         )
       ):
-        state.routes.push(.newsCard(
-          .init(routes: [
-            .root(
-              .newsList(
-                .init(
-                  shortsId: id,
-                  keywordTitle: keyword
-                )
-              ),
-              embedInNavigationView: true
-            )
-          ])
-        ))
+        state.routes.push(.newsCard(.init(source: .mypage, shortsId: id, keywordTitle: keyword)))
         return .none
         
       case let .routeAction(
@@ -234,7 +193,7 @@ public let appCoordinatorReducer: Reducer<
           )
         )
       ):
-        state.routes.push(.newsCard(.init(routes: [.root(.web(.init(webAddress: "https://naver.com")))])))
+        state.routes.push(.newsCard(.init(webAddress: "https://naver.com")))
         return .none
         
       case let .routeAction(
@@ -258,13 +217,13 @@ public let appCoordinatorReducer: Reducer<
           )
         )
       ):
-        state.routes.push(.newsCard(.init(routes: [.root(.web(.init(webAddress: "https://naver.com")))])))
+        state.routes.push(.newsCard(.init(webAddress: "https://naver.com")))
         return .none
         
       case .routeAction(_, action: .newsCard(.routeAction(_, action: .web(.backButtonTapped)))):
         state.routes.pop()
         return .none
-
+        
       case .routeAction(_, action: .newsCard(.routeAction(_, action: .shortsComplete(.backButtonTapped)))):
         state.routes.pop()
         return Effect(
@@ -311,9 +270,15 @@ public let appCoordinatorReducer: Reducer<
           )
         )
         
-      case .routeAction(_, action: .newsCard(.routeAction(_, action: .newsList(.backButtonTapped)))):
+      case let .routeAction(_, action: .newsCard(.routeAction(_, action: .newsList(.backButtonTapped(source))))):
         state.routes.pop()
-        return Effect(value: .routeAction(0, action: .tabBar(._setTabHiddenStatus(false))))
+        switch source {
+        case .main, .hot:
+          return Effect(value: .routeAction(0, action: .tabBar(._setTabHiddenStatus(false))))
+          
+        case .mypage:
+          return .none
+        }
         
       default: return .none
       }

--- a/Projects/Features/Coordinator/NewsCardCoordinator/NewsCardCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/NewsCardCoordinator/NewsCardCoordinatorCore.swift
@@ -16,20 +16,26 @@ public struct NewsCardCoordinatorState: Equatable, IndexedRouterState {
   public var routes: [Route<NewsCardScreenState>]
   
   public init(
-    routes: [Route<NewsCardScreenState>] = [
+    source: SourceType,
+    shortsId: Int,
+    keywordTitle: String
+  ) {
+    self.routes = [
       .root(
         .newsList(
           .init(
-            shortsId: 0,
-            keywordTitle: "",
-            newsItems: []
+            source: source,
+            shortsId: shortsId,
+            keywordTitle: keywordTitle
           )
         ),
         embedInNavigationView: true
       )
     ]
-  ) {
-    self.routes = routes
+  }
+  
+  public init(webAddress: String) {
+    self.routes = [.root(.web(.init(webAddress: webAddress)))]
   }
 }
 

--- a/Projects/Features/Scene/NewsCardScene/NewsList/NewsListCore.swift
+++ b/Projects/Features/Scene/NewsCardScene/NewsList/NewsListCore.swift
@@ -42,7 +42,7 @@ public struct NewsListState: Equatable {
 
 public enum NewsListAction: Equatable {
   // MARK: - User Action
-  case backButtonTapped
+  case backButtonTapped(SourceType)
   case completeButtonTapped
   
   // MARK: - Inner Business Action

--- a/Projects/Features/Scene/NewsCardScene/NewsList/NewsListView.swift
+++ b/Projects/Features/Scene/NewsCardScene/NewsList/NewsListView.swift
@@ -24,7 +24,7 @@ public struct NewsListView: View {
           TopNavigationBar(
             leftIcon: DesignSystem.Icons.iconNavigationLeft,
             leftIconButtonAction: {
-              viewStore.send(.backButtonTapped)
+              viewStore.send(.backButtonTapped(viewStore.source))
             }
           )
           


### PR DESCRIPTION
## Task 
close #106 

## 참고
- 뉴스 리스트의 source가 mypage이면 `tabbar hidden false`를 하지 않게 했습니다.
```swift
case let .routeAction(_, action: .newsCard(.routeAction(_, action: .newsList(.backButtonTapped(source))))):
        state.routes.pop()
        switch source {
        case .main, .hot:
          return Effect(value: .routeAction(0, action: .tabBar(._setTabHiddenStatus(false))))
          
        case .mypage:
          return .none
        }
```

## 스크린 샷
![Simulator Screen Recording - iPhone 14 Pro Max - 2023-07-04 at 13 44 24](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/48887389/9723023d-1914-40e3-8524-4bccd9b4c568)

