### PR TITLE
오래된 숏스 카테고리 필터 바텀 시트 구현

### DIFF
--- a/Projects/Core/Common/Category/CategoryType.swift
+++ b/Projects/Core/Common/Category/CategoryType.swift
@@ -38,14 +38,14 @@ public enum CategoryType: String, CaseIterable {
     }
   }
   
-  public var indexValue: Int {
-    var indexValue = -1
-    for (index, item) in Self.allCases.enumerated() {
-      if item.rawValue == self.rawValue {
-        indexValue = index
-        break
-      }
+  public var indexValue: Int? {
+    Self.allCases.firstIndex(where: { $0.rawValue == self.rawValue })
+  }
+  
+  public static func compare(_ left: CategoryType, _ right: CategoryType) -> Bool {
+    if let leftIndex = left.indexValue, let rightIndex = right.indexValue {
+      return leftIndex < rightIndex
     }
-    return indexValue
+    return false
   }
 }

--- a/Projects/Core/Common/Category/CategoryType.swift
+++ b/Projects/Core/Common/Category/CategoryType.swift
@@ -37,4 +37,15 @@ public enum CategoryType: String, CaseIterable {
       return nil
     }
   }
+  
+  public var indexValue: Int {
+    var indexValue = -1
+    for (index, item) in Self.allCases.enumerated() {
+      if item.rawValue == self.rawValue {
+        indexValue = index
+        break
+      }
+    }
+    return indexValue
+  }
 }

--- a/Projects/DesignSystem/Sources/Views/BottomSheet/BottomSheet.swift
+++ b/Projects/DesignSystem/Sources/Views/BottomSheet/BottomSheet.swift
@@ -9,10 +9,12 @@
 import SwiftUI
 
 public struct BottomSheet<
+  BackgroundColor: View,
   HeaderArea: View,
   Content: View,
   BottomArea: View
 >: View {
+  private var backgroundColor: BackgroundColor
   @Binding private var isPresented: Bool
   private var headerArea: HeaderArea
   private var content: Content
@@ -24,11 +26,13 @@ public struct BottomSheet<
     .first { $0.isKeyWindow }
   
   public init(
+    backgroundColor: BackgroundColor,
     isPresented: Binding<Bool>,
     @ViewBuilder headerArea: () -> HeaderArea,
     @ViewBuilder content: () -> Content,
     @ViewBuilder bottomArea: () -> BottomArea
   ) {
+    self.backgroundColor = backgroundColor
     self._isPresented = isPresented
     self.headerArea = headerArea()
     self.content = content()
@@ -51,17 +55,19 @@ public struct BottomSheet<
         .frame(height: keyWindow?.safeAreaInsets.bottom)
         .padding(.top, 8)
     }
-    .background(Color.white.opacity(0.8).blurEffect())
+    .background(backgroundColor)
     .clipShape(RoundCorners())
   }
 }
 
 public extension View {
   func bottomSheet<
+    BackgroundColor: View,
     HeaderArea: View,
     Content: View,
     BottomArea: View
   >(
+    backgroundColor: BackgroundColor = Color.white,
     isPresented: Binding<Bool>,
     @ViewBuilder headerArea: () -> HeaderArea,
     @ViewBuilder content: () -> Content,
@@ -81,6 +87,7 @@ public extension View {
             .transition(.opacity)
           
           BottomSheet(
+            backgroundColor: backgroundColor,
             isPresented: isPresented,
             headerArea: headerArea,
             content: content,

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheet.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheet.swift
@@ -1,0 +1,63 @@
+//
+//  CategoryFilterBottomSheet.swift
+//  Splash
+//
+//  Created by 김영균 on 2023/07/05.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import ComposableArchitecture
+import DesignSystem
+import SwiftUI
+
+struct CategoryFilterBottomSheet: ViewModifier {
+  private let store: Store<LongStorageNewsListState, LongStorageNewsListAction>
+  
+  init(store: Store<LongStorageNewsListState, LongStorageNewsListAction>) {
+    self.store = store
+  }
+  
+  func body(content: Content) -> some View {
+    WithViewStore(store) { viewStore in
+      content
+        .bottomSheet(
+          isPresented: viewStore.binding(
+            get: \.categoryFilterBottomSheetState.isPresented,
+            send: { .categoryFilterBottomSheet(._setIsPresented($0)) }
+          ),
+          headerArea: {
+            CategoryFilterBottomSheetHeader(
+              store: store.scope(
+                state: \.categoryFilterBottomSheetState,
+                action: LongStorageNewsListAction.categoryFilterBottomSheet
+              )
+            )
+            
+          },
+          content: {
+            CategoryFilterBottomSheetContent(
+              store: store.scope(
+                state: \.categoryFilterBottomSheetState,
+                action: LongStorageNewsListAction.categoryFilterBottomSheet
+              )
+            )
+          },
+          bottomArea: {
+            CategoryFilterBottomSheetFooter(
+              store: store.scope(
+                state: \.categoryFilterBottomSheetState,
+                action: LongStorageNewsListAction.categoryFilterBottomSheet
+              )
+              .stateless
+            )
+          }
+        )
+    }
+  }
+}
+
+extension View {
+  func filterBottomSheet(store: Store<LongStorageNewsListState, LongStorageNewsListAction>) -> some View {
+    modifier(CategoryFilterBottomSheet(store: store))
+  }
+}

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheet.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheet.swift
@@ -48,7 +48,6 @@ struct CategoryFilterBottomSheet: ViewModifier {
                 state: \.categoryFilterBottomSheetState,
                 action: LongStorageNewsListAction.categoryFilterBottomSheet
               )
-              .stateless
             )
           }
         )

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheetContent.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheetContent.swift
@@ -1,0 +1,136 @@
+//
+//  CategoryFilterBottomSheetContent.swift
+//  Splash
+//
+//  Created by 김영균 on 2023/07/05.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import Common
+import ComposableArchitecture
+import DesignSystem
+import SwiftUI
+
+struct CategoryFilterBottomSheetContent: View {
+  private let columns = [
+    GridItem(.flexible()),
+    GridItem(.flexible()),
+    GridItem(.flexible()),
+    GridItem(.flexible())
+  ]
+  private let store: Store<CategoryFilterBottomSheetState, CategoryFilterBottomSheetAction>
+  
+  init(store: Store<CategoryFilterBottomSheetState, CategoryFilterBottomSheetAction>) {
+    self.store = store
+  }
+  
+  var body: some View {
+    WithViewStore(store) { viewStore in
+      ScrollView {
+        LazyVGrid(columns: columns, spacing: 16) {
+          ForEach(viewStore.allCateogires, id: \.self) { category in
+            CategoryItemView(
+              selectedCategories: viewStore.binding(
+                get: \.selectedCategories,
+                send: CategoryFilterBottomSheetAction._setSelectedCategories
+              ),
+              category: category
+            )
+          }
+        }
+      }
+      .scrollDisabled(true)
+      .frame(height: 218)
+    }
+  }
+}
+
+// MARK: - 카테고리 아이템 뷰
+private struct CategoryItemView: View {
+  @Binding private var selectedCategories: Set<CategoryType>
+  private var category: CategoryType
+  private var isSelected: Bool { selectedCategories.contains(category) }
+  private var iconImage: Image {
+    if isSelected {
+      return category.selectedIcon
+    } else {
+      return category.defaultIcon
+    }
+  }
+  
+  fileprivate init(
+    selectedCategories: Binding<Set<CategoryType>>,
+    category: CategoryType
+  ) {
+    self._selectedCategories = selectedCategories
+    self.category = category
+  }
+  
+  fileprivate var body: some View {
+    VStack(spacing: 8) {
+      iconImage
+        .frame(width: 76, height: 76)
+        .background(
+          RoundedRectangle(cornerRadius: 16)
+            .fill(
+              LinearGradient(
+                colors: [
+                  DesignSystem.Colors.white.opacity(0.6),
+                  DesignSystem.Colors.white.opacity(0.3)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+              )
+            )
+        )
+        .onTapGesture {
+          if selectedCategories.contains(category) {
+            selectedCategories.remove(category)
+          } else {
+            selectedCategories.insert(category)
+          }
+        }
+      
+      Text(category.rawValue)
+        .font(.r14)
+        .foregroundColor(DesignSystem.Colors.grey100)
+    }
+  }
+}
+
+// MARK: - 카테고리 타입 Extension
+fileprivate extension CategoryType {
+  var defaultIcon: Image {
+    switch self {
+    case .politics:
+      return DesignSystem.Icons.politicsSmall
+    case .economic:
+      return DesignSystem.Icons.economicSmall
+    case .society:
+      return DesignSystem.Icons.societySmall
+    case .world:
+      return DesignSystem.Icons.worldSmall
+    case .culture:
+      return DesignSystem.Icons.cultureSmall
+    case .science:
+      return DesignSystem.Icons.scienceSmall
+    }
+  }
+  
+  var selectedIcon: Image {
+    switch self {
+    case .politics:
+      return DesignSystem.Icons.selectPoliticsSmall
+    case .economic:
+      return DesignSystem.Icons.selectEconomicSmall
+    case .society:
+      return DesignSystem.Icons.selectSocietySmall
+    case .world:
+      return DesignSystem.Icons.selectWorldSmall
+    case .culture:
+      return DesignSystem.Icons.selectCultureSmall
+    case .science:
+      return DesignSystem.Icons.selectScienceSmall
+    }
+  }
+}

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheetCore.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheetCore.swift
@@ -64,7 +64,6 @@ public let categoryFilterBottomSheetReducer = Reducer<
     return .none
     
   case let ._setSelectedCategories(selectedCategories):
-    print(selectedCategories)
     state.selectedCategories = selectedCategories
     return .none
     

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheetCore.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheetCore.swift
@@ -1,0 +1,75 @@
+//
+//  CategoryFilterBottomSheetCore.swift
+//  Splash
+//
+//  Created by 김영균 on 2023/07/05.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import Common
+import ComposableArchitecture
+import Foundation
+
+public struct CategoryFilterBottomSheetState: Equatable {
+  var allCateogires: [CategoryType]
+  var selectedCategories: Set<CategoryType>
+  var isPresented: Bool
+  
+  init(
+    allCateogires: [CategoryType] = CategoryType.allCases,
+    selectedCategories: Set<CategoryType> = [],
+    isPresented: Bool = false
+  ) {
+    self.allCateogires = allCateogires
+    self.selectedCategories = selectedCategories
+    self.isPresented = isPresented
+  }
+}
+
+public enum CategoryFilterBottomSheetAction {
+  // MARK: User Action
+  case confirmBottomButtonTapped
+  case selectCategory(CategoryType)
+  
+  // MARK: Inner Business Action
+  case _filter(Set<CategoryType>) // 상위 코어에 전달하는 액션.
+  
+  // MARK: Inner Set State Action
+  case _setSelectedCategories(Set<CategoryType>)
+  case _setIsPresented(Bool)
+}
+
+public struct CategoryFilterBottomSheetEnvironment {
+  init() { }
+}
+
+public let categoryFilterBottomSheetReducer = Reducer<
+  CategoryFilterBottomSheetState,
+  CategoryFilterBottomSheetAction,
+  CategoryFilterBottomSheetEnvironment
+> { state, action, _ in
+  switch action {
+  case .confirmBottomButtonTapped:
+    return Effect(value: ._filter(state.selectedCategories))
+    
+  case let .selectCategory(category):
+    if state.selectedCategories.contains(category) {
+      state.selectedCategories.remove(category)
+    } else {
+      state.selectedCategories.insert(category)
+    }
+    return .none
+    
+  case ._filter:
+    return .none
+    
+  case let ._setSelectedCategories(selectedCategories):
+    print(selectedCategories)
+    state.selectedCategories = selectedCategories
+    return .none
+    
+  case let ._setIsPresented(isPresented):
+    state.isPresented = isPresented
+    return .none
+  }
+}

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheetFooter.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheetFooter.swift
@@ -12,16 +12,17 @@ import DesignSystem
 import SwiftUI
 
 struct CategoryFilterBottomSheetFooter: View {
-  private let store: Store<Void, CategoryFilterBottomSheetAction>
+  private let store: Store<CategoryFilterBottomSheetState, CategoryFilterBottomSheetAction>
   
-  init(store: Store<Void, CategoryFilterBottomSheetAction>) {
+  init(store: Store<CategoryFilterBottomSheetState, CategoryFilterBottomSheetAction>) {
     self.store = store
   }
   
   var body: some View {
-    WithViewStore(store) { viewStore in
+    WithViewStore(store, observe: \.selectedCategories) { viewStore in
       BottomButton(
         title: "확인",
+        disabled: viewStore.state.isEmpty,
         action: {
           viewStore.send(.confirmBottomButtonTapped)
         }

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheetFooter.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheetFooter.swift
@@ -1,0 +1,31 @@
+//
+//  CategoryFilterBottomSheetFooter.swift
+//  Splash
+//
+//  Created by 김영균 on 2023/07/05.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import Common
+import ComposableArchitecture
+import DesignSystem
+import SwiftUI
+
+struct CategoryFilterBottomSheetFooter: View {
+  private let store: Store<Void, CategoryFilterBottomSheetAction>
+  
+  init(store: Store<Void, CategoryFilterBottomSheetAction>) {
+    self.store = store
+  }
+  
+  var body: some View {
+    WithViewStore(store) { viewStore in
+      BottomButton(
+        title: "확인",
+        action: {
+          viewStore.send(.confirmBottomButtonTapped)
+        }
+      )
+    }
+  }
+}

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheetHeader.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheetHeader.swift
@@ -1,0 +1,87 @@
+//
+//  CategoryFilterBottomSheetHeader.swift
+//  Splash
+//
+//  Created by 김영균 on 2023/07/05.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import Common
+import ComposableArchitecture
+import DesignSystem
+import SwiftUI
+
+struct CategoryFilterBottomSheetHeader: View {
+  private let store: Store<CategoryFilterBottomSheetState, CategoryFilterBottomSheetAction>
+  
+  init(store: Store<CategoryFilterBottomSheetState, CategoryFilterBottomSheetAction>) {
+    self.store = store
+  }
+  
+  var body: some View {
+    WithViewStore(store, observe: \.selectedCategories) { viewStore in
+      VStack {
+        HStack {
+          Text("필터")
+            .font(.b18)
+            .foregroundColor(DesignSystem.Colors.grey100)
+          Spacer()
+        }
+        
+        Spacer()
+          .frame(height: 16)
+        
+        ScrollView(.horizontal, showsIndicators: false) {
+          HStack(spacing: 8) {
+            ForEach(Array(viewStore.state), id: \.self) { category in
+              CategoryBadge(category: category)
+                .onTapGesture {
+                  viewStore.send(.selectCategory(category))
+                }
+            }
+          }
+        }
+      }
+      .padding(.horizontal, 24)
+    }
+  }
+}
+
+private struct CategoryBadge: View {
+  private let category: CategoryType
+  
+  fileprivate init(category: CategoryType) {
+    self.category = category
+  }
+  
+  fileprivate var body: some View {
+    HStack(spacing: 2) {
+      Text(category.rawValue)
+        .font(.r14)
+        .foregroundColor(DesignSystem.Colors.grey90)
+        .frame(height: 17)
+      
+      DesignSystem.Icons.iconX
+        .frame(width: 14, height: 14)
+    }
+    .padding(.leading, 14)
+    .padding(.trailing, 10)
+    .padding(.vertical, 8)
+    .background(DesignSystem.Colors.grey20)
+    .cornerRadius(24)
+    .overlay {
+      RoundedRectangle(cornerRadius: 24)
+        .strokeBorder(
+          LinearGradient(
+            colors: [
+              DesignSystem.Colors.white,
+              DesignSystem.Colors.white.opacity(0.2)
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+          ),
+          lineWidth: 1
+        )
+    }
+  }
+}

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheetHeader.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheetHeader.swift
@@ -34,7 +34,7 @@ struct CategoryFilterBottomSheetHeader: View {
         ScrollView(.horizontal, showsIndicators: false) {
           HStack(spacing: 8) {
             ForEach(
-              viewStore.state.sorted(by: { $0.indexValue < $1.indexValue }),
+              viewStore.state.sorted(by: CategoryType.compare),
               id: \.self
             ) { category in
               CategoryBadge(category: category)

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheetHeader.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/CategoryFilterBottomSheet/CategoryFilterBottomSheetHeader.swift
@@ -33,7 +33,10 @@ struct CategoryFilterBottomSheetHeader: View {
         
         ScrollView(.horizontal, showsIndicators: false) {
           HStack(spacing: 8) {
-            ForEach(Array(viewStore.state), id: \.self) { category in
+            ForEach(
+              viewStore.state.sorted(by: { $0.indexValue < $1.indexValue }),
+              id: \.self
+            ) { category in
               CategoryBadge(category: category)
                 .onTapGesture {
                   viewStore.send(.selectCategory(category))

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageNewsListView.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageNewsListView.swift
@@ -183,7 +183,7 @@ private struct FilterBottomSheetButton: View {
   }
     
   private func buildSelectedCategoriesText(_ selectedCategories: Set<CategoryType>) -> String {
-    let sortedSelectedCategories = selectedCategories.sorted { $0.indexValue < $1.indexValue }
+    let sortedSelectedCategories = selectedCategories.sorted(by: CategoryType.compare)
     if sortedSelectedCategories.isEmpty || sortedSelectedCategories.count == CategoryType.allCases.count {
       return "전체"
     } else {

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageNewsListView.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageNewsListView.swift
@@ -49,7 +49,15 @@ public struct LongStorageNewsListView: View {
             
             // 필터 뷰
             if !viewStore.state.isInEditMode && viewStore.state.shortsNewsItemsCount != 0 {
-              FilterView(store: store.scope(state: \.sortType))
+              HStack {
+                SortBottomSheetButton(store: store.scope(state: \.sortType))
+                Spacer()
+                FilterBottomSheetButton(store: store.scope(state: \.selectedCategories))
+              }
+              .padding(.horizontal, 24)
+              
+              Spacer()
+                .frame(height: 16)
             }
             
             if viewStore.shortsNewsItemsCount == 0 {
@@ -83,30 +91,8 @@ public struct LongStorageNewsListView: View {
       .onAppear {
         viewStore.send(._onAppear)
       }
-      .bottomSheet(
-        isPresented: viewStore.binding(
-          get: \.sortBottomSheetState.isPresented,
-          send: { .sortBottomSheet(._setIsPresented($0)) }
-        ),
-        headerArea: { LongStorageSortBottomSheetHeader() },
-        content: {
-          LongStorageSortBottomSheetContent(
-            store: store.scope(
-              state: \.sortBottomSheetState,
-              action: LongStorageNewsListAction.sortBottomSheet
-            )
-          )
-        },
-        bottomArea: {
-          LongStorageSortBottomSheetFooter(
-            store: store.scope(
-              state: \.sortBottomSheetState,
-              action: LongStorageNewsListAction.sortBottomSheet
-            )
-            .stateless
-          )
-        }
-      )        
+      .longStorageSortBottomSheet(store: store)
+      .filterBottomSheet(store: store)
     }
   }
 }
@@ -153,7 +139,8 @@ private struct MonthInfoView: View {
   }
 }
 
-private struct FilterView: View {
+// 정렬 바텀시트 버튼
+private struct SortBottomSheetButton: View {
   private let store: Store<SortType, LongStorageNewsListAction>
   
   fileprivate init(store: Store<SortType, LongStorageNewsListAction>) {
@@ -162,34 +149,46 @@ private struct FilterView: View {
   
   fileprivate var body: some View {
     WithViewStore(store) { viewStore in
-      VStack(spacing: 0) {
-        HStack(spacing: 0) {
-          Group {
-            Text(viewStore.state.rawValue)
-              .font(.r14)
-              .foregroundColor(DesignSystem.Colors.grey70)
-            
-            DesignSystem.Icons.iconChevronDown
-          }
-          .onTapGesture {
-            viewStore.send(.showSortBottomSheet)
-          }
-          
-          Spacer()
-          
-          Group {
-            Text("전체")
-              .font(.r14)
-              .foregroundColor(DesignSystem.Colors.grey70)
-            
-            DesignSystem.Icons.iconChevronDown
-          }
-        }
-        .padding(.horizontal, 24)
+      HStack(spacing: 0) {
+        Text(viewStore.state.rawValue)
+          .font(.r14)
+          .foregroundColor(DesignSystem.Colors.grey70)
         
-        Spacer()
-          .frame(height: 16)
+        DesignSystem.Icons.iconChevronDown
       }
+      .onTapGesture { viewStore.send(.showSortBottomSheet) }
+    }
+  }
+}
+
+// 카테고리 필터 바텀시트 버튼
+private struct FilterBottomSheetButton: View {
+  private let store: Store<Set<CategoryType>, LongStorageNewsListAction>
+  
+  fileprivate init(store: Store<Set<CategoryType>, LongStorageNewsListAction>) {
+    self.store = store
+  }
+  
+  fileprivate var body: some View {
+    WithViewStore(store) { viewStore in
+      HStack(spacing: 0) {
+        Text(buildSelectedCategoriesText(viewStore.state))
+          .font(.r14)
+          .foregroundColor(DesignSystem.Colors.grey70)
+        
+        DesignSystem.Icons.iconChevronDown
+      }
+      .onTapGesture { viewStore.send(.showCategoryFilterBottomSheet) }
+    }
+  }
+    
+  private func buildSelectedCategoriesText(_ selectedCategories: Set<CategoryType>) -> String {
+    if selectedCategories.isEmpty || selectedCategories.count == CategoryType.allCases.count {
+      return "전체"
+    } else {
+      return selectedCategories
+        .map { $0.rawValue }
+        .joined(separator: "•")
     }
   }
 }

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageNewsListView.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageNewsListView.swift
@@ -183,10 +183,11 @@ private struct FilterBottomSheetButton: View {
   }
     
   private func buildSelectedCategoriesText(_ selectedCategories: Set<CategoryType>) -> String {
-    if selectedCategories.isEmpty || selectedCategories.count == CategoryType.allCases.count {
+    let sortedSelectedCategories = selectedCategories.sorted { $0.indexValue < $1.indexValue }
+    if sortedSelectedCategories.isEmpty || sortedSelectedCategories.count == CategoryType.allCases.count {
       return "전체"
     } else {
-      return selectedCategories
+      return sortedSelectedCategories
         .map { $0.rawValue }
         .joined(separator: "•")
     }

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageSortBottomSheet/LongStorageSortBottomSheet.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageSortBottomSheet/LongStorageSortBottomSheet.swift
@@ -1,0 +1,55 @@
+//
+//  LongStorageSortBottomSheet.swift
+//  LongStorageNewsList
+//
+//  Created by 김영균 on 2023/07/05.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import ComposableArchitecture
+import DesignSystem
+import SwiftUI
+
+struct LongStorageSortBottomSheet: ViewModifier {
+  private let store: Store<LongStorageNewsListState, LongStorageNewsListAction>
+  
+  init(store: Store<LongStorageNewsListState, LongStorageNewsListAction>) {
+    self.store = store
+  }
+  
+  func body(content: Content) -> some View {
+    WithViewStore(store) { viewStore in
+      content
+        .bottomSheet(
+          isPresented: viewStore.binding(
+            get: \.sortBottomSheetState.isPresented,
+            send: { .sortBottomSheet(._setIsPresented($0)) }
+          ),
+          headerArea: { LongStorageSortBottomSheetHeader() },
+          content: {
+            LongStorageSortBottomSheetContent(
+              store: store.scope(
+                state: \.sortBottomSheetState,
+                action: LongStorageNewsListAction.sortBottomSheet
+              )
+            )
+          },
+          bottomArea: {
+            LongStorageSortBottomSheetFooter(
+              store: store.scope(
+                state: \.sortBottomSheetState,
+                action: LongStorageNewsListAction.sortBottomSheet
+              )
+              .stateless
+            )
+          }
+        )
+    }
+  }
+}
+
+extension View {
+  func longStorageSortBottomSheet(store: Store<LongStorageNewsListState, LongStorageNewsListAction>) -> some View {
+    modifier(LongStorageSortBottomSheet(store: store))
+  }
+}

--- a/Projects/Features/Scene/TabBarScene/TabBar/TabBarView.swift
+++ b/Projects/Features/Scene/TabBarScene/TabBar/TabBarView.swift
@@ -75,6 +75,7 @@ public struct TabBarView: View {
         }
       })
       .bottomSheet(
+        backgroundColor: DesignSystem.Colors.white.opacity(0.62).blurEffect(),
         isPresented: viewStore.binding(
           get: \.categoryBottomSheet.isPresented,
           send: {


### PR DESCRIPTION
## Task
- #124 

## 참고
- 선택된 카테고리를 관리하는데 `contains` 연산을 자주 사용해서 자료구조를 Array 대신 Set으로 가져갔습니다!~
```swift
var selectedCategories: Set<CategoryType>

case let .selectCategory(category):
  if state.selectedCategories.contains(category) {
    state.selectedCategories.remove(category)
  } else {
    state.selectedCategories.insert(category)
  }
  return .none
```

## 스크린샷
![Simulator Screen Recording - iPhone 14 Pro Max - 2023-07-05 at 15 25 55](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/48887389/c6da6f46-9341-4c00-8cec-8c8297140c18)
