### PR TITLE
버그: 웹 뷰에서 뒤로가기 버그 수정

### DIFF
--- a/Projects/Core/Common/Source/SourceType.swift
+++ b/Projects/Core/Common/Source/SourceType.swift
@@ -1,0 +1,16 @@
+//
+//  SourceType.swift
+//  CoreKit
+//
+//  Created by 김영균 on 2023/07/06.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import Foundation
+
+public enum SourceType: Equatable {
+  case main
+  case hot
+  case shortStorage
+  case longStorage
+}

--- a/Projects/Features/Coordinator/AppCoordinator/AppCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/AppCoordinator/AppCoordinatorCore.swift
@@ -169,7 +169,7 @@ public let appCoordinatorReducer: Reducer<
           )
         )
       ):
-        state.routes.push(.newsCard(.init(source: .mypage, shortsId: id, keywordTitle: keyword)))
+        state.routes.push(.newsCard(.init(source: .shortStorage, shortsId: id, keywordTitle: keyword)))
         return .none
         
       case let .routeAction(
@@ -194,7 +194,7 @@ public let appCoordinatorReducer: Reducer<
         )
       ):
         // TODO: 실데이터 반영 필요
-        state.routes.push(.newsCard(.init(routes: [.root(.web(.init(newsId: id, webAddress: "https://naver.com")))])))
+        state.routes.push(.newsCard(.init(source: .longStorage, webAddress: "https://naver.com")))
         return .none
         
       case let .routeAction(
@@ -218,11 +218,13 @@ public let appCoordinatorReducer: Reducer<
           )
         )
       ):
-        state.routes.push(.newsCard(.init(routes: [.root(.web(.init(newsId: id, webAddress: "https://naver.com")))])))
+        state.routes.push(.newsCard(.init(source: .longStorage, webAddress: "https://naver.com")))
         return .none
         
-      case .routeAction(_, action: .newsCard(.routeAction(_, action: .web(.backButtonTapped)))):
-        state.routes.pop()
+      case let .routeAction(_, action: .newsCard(.routeAction(_, action: .web(.backButtonTapped(source))))):
+        if source == .longStorage {
+          state.routes.pop()
+        }
         return .none
         
       case .routeAction(_, action: .newsCard(.routeAction(_, action: .shortsComplete(.backButtonTapped)))):
@@ -277,7 +279,7 @@ public let appCoordinatorReducer: Reducer<
         case .main, .hot:
           return Effect(value: .routeAction(0, action: .tabBar(._setTabHiddenStatus(false))))
           
-        case .mypage:
+        case .shortStorage, .longStorage:
           return .none
         }
         

--- a/Projects/Features/Coordinator/NewsCardCoordinator/NewsCardCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/NewsCardCoordinator/NewsCardCoordinatorCore.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
 //
 
+import Common
 import ComposableArchitecture
 import NewsList
 import Services
@@ -34,8 +35,8 @@ public struct NewsCardCoordinatorState: Equatable, IndexedRouterState {
     ]
   }
   
-  public init(webAddress: String) {
-    self.routes = [.root(.web(.init(webAddress: webAddress)))]
+  public init(source: SourceType, webAddress: String) {
+    self.routes = [.root(.web(.init(source: source, newsId: 0, webAddress: webAddress)))]
   }
 }
 
@@ -75,9 +76,19 @@ public let newsCardCoordinatorReducer: Reducer<
         state.routes.push(.shortsComplete(.init(totalShortsCount: totalShortsCount)))
         return .none
         
-      case let .routeAction(_, action: .newsList(.newsItem(id: id, action: ._navigateWebView(url)))):
-        state.routes.push(.web(.init(newsId: id, webAddress: url)))
+      case let .routeAction(_, action: .newsList(.navigateWebView(source, id, url))):
+        state.routes.push(.web(.init(source: source, newsId: id, webAddress: url)))
         return .none
+        
+      case let .routeAction(_, action: .web(.backButtonTapped(source))):
+        switch source {
+        case .hot, .main, .shortStorage:
+          state.routes.pop()
+          return .none
+          
+        case .longStorage:
+          return .none
+        }
         
       default: return .none
       }

--- a/Projects/Features/Scene/NewsCardScene/NewsList/NewsListCore.swift
+++ b/Projects/Features/Scene/NewsCardScene/NewsList/NewsListCore.swift
@@ -13,12 +13,6 @@ import Foundation
 import Models
 import Services
 
-public enum SourceType: Equatable {
-  case main
-  case hot
-  case mypage
-}
-
 public struct NewsListState: Equatable {
   var source: SourceType
   var shortsId: Int
@@ -31,7 +25,7 @@ public struct NewsListState: Equatable {
   var pagingSize = 20
   
   public init(
-    source: SourceType = .mypage,
+    source: SourceType,
     shortsId: Int,
     keywordTitle: String,
     newsItems: IdentifiedArrayOf<NewsCardState> = []
@@ -50,6 +44,7 @@ public enum NewsListAction {
   case backButtonTapped(SourceType)
   case completeButtonTapped
   case showSortBottomSheet
+  case navigateWebView(SourceType, Int, String)
   
   // MARK: - Inner Business Action
   case _onAppear
@@ -101,6 +96,9 @@ public let newsListReducer = Reducer.combine([
       
     case .showSortBottomSheet:
       return Effect(value: .sortBottomSheet(._setIsPresented(true)))
+      
+    case .navigateWebView:
+      return .none
       
     case ._onAppear:
       return Effect(value: ._handleNewsResponse(state.source))
@@ -172,6 +170,9 @@ public let newsListReducer = Reducer.combine([
         Effect(value: ._sortNewsItems(sortType)),
         Effect(value: .sortBottomSheet(._setIsPresented(false)))
       )
+      
+    case let .newsItem(id, action: ._navigateWebView(url)):
+      return Effect(value: .navigateWebView(state.source, id, url))
       
     default: return .none
     }

--- a/Projects/Features/Scene/WebScene/Web/WebCore.swift
+++ b/Projects/Features/Scene/WebScene/Web/WebCore.swift
@@ -13,6 +13,7 @@ import Foundation
 import Services
 
 public struct WebState: Equatable {
+  var source: SourceType
   var newsId: Int
   var webAddress: String
   var saveButtonDisabled: Bool
@@ -21,11 +22,13 @@ public struct WebState: Equatable {
   var warningToastMessage: String?
   
   public init(
+    source: SourceType,
     newsId: Int,
     webAddress: String,
     saveButtonDisabled: Bool = false,
     isDisplayTooltip: Bool = true
   ) {
+    self.source = source
     self.newsId = newsId
     self.webAddress = webAddress
     self.saveButtonDisabled = saveButtonDisabled
@@ -35,7 +38,7 @@ public struct WebState: Equatable {
 
 public enum WebAction: Equatable {
   // MARK: - User Action
-  case backButtonTapped
+  case backButtonTapped(SourceType)
   case saveButtonTapped
   case tooltipButtonTapped
   

--- a/Projects/Features/Scene/WebScene/Web/WebView.swift
+++ b/Projects/Features/Scene/WebScene/Web/WebView.swift
@@ -24,7 +24,7 @@ public struct WebView: View {
         VStack {
           TopNavigationBar(
             leftIcon: DesignSystem.Icons.iconNavigationLeft,
-            leftIconButtonAction: { viewStore.send(.backButtonTapped) },
+            leftIconButtonAction: { viewStore.send(.backButtonTapped(viewStore.source)) },
             rightText: "저장",
             rightIconButtonAction: { viewStore.send(.saveButtonTapped) },
             isRightButtonActive: viewStore.binding(


### PR DESCRIPTION
## Task
- close #127 

## 참고
- SourceType을 Common으로 옮겼습니다
- WebCore도 SourceType을 갖도록 해서 어떤 뷰에서 웹 뷰를 띄웠는지 알 수 있습니다.
- 라우팅은 아래 사진을 참고하시면 이해가 편합니다!
<img src="https://user-images.githubusercontent.com/95578975/239683819-fd4e4db4-fc00-45eb-ae63-2af736e7aaef.png" width="700"/>


## 스크린샷
![Simulator Screen Recording - iPhone 14 Pro Max - 2023-07-06 at 09 41 40](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/48887389/5f646a5b-6c1f-4e3e-a731-61d25adb86ef)
