### PR TITLE
버그: 메인, 핫키워드에서 진입하는 뉴스 리스트의 바텀 버튼 동작 수정

### DIFF
--- a/Projects/Features/Scene/NewsCardScene/NewsList/NewsListCore.swift
+++ b/Projects/Features/Scene/NewsCardScene/NewsList/NewsListCore.swift
@@ -45,6 +45,7 @@ public enum NewsListAction {
   // MARK: - User Action
   case backButtonTapped(SourceType)
   case completeButtonTapped
+  case saveButtonTapped
   case showSortBottomSheet
   case navigateWebView(SourceType, Int, String)
   
@@ -52,7 +53,9 @@ public enum NewsListAction {
   case _onAppear
   case _willDisappear(Int)
   case _completeTodayShorts(Int)
+  case _saveTodayShorts(Int)
   case _handleNewsResponse(SourceType)
+  case _handleSaveTodayShortsResponse(Result<VoidResponse?, Error>)
   case _sortNewsItems(SortType)
   case _presentSuccessToast(String)
   case _presentFailureToast(String)
@@ -110,6 +113,9 @@ public let newsListReducer = Reducer.combine([
     case .completeButtonTapped:
       return Effect(value: ._completeTodayShorts(state.shortsId))
       
+    case .saveButtonTapped:
+      return Effect(value: ._saveTodayShorts(state.shortsId))
+      
     case .showSortBottomSheet:
       return Effect(value: .sortBottomSheet(._setIsPresented(true)))
       
@@ -138,8 +144,18 @@ public let newsListReducer = Reducer.combine([
         }
         .eraseToEffect()
       
+    case let ._saveTodayShorts(shortsId):
+      return env.newsCardService.saveNewsCard(shortsId)
+        .catchToEffect(NewsListAction._handleSaveTodayShortsResponse)
+      
     case let ._handleNewsResponse(source):
       return handleSourceType(&state, env, source: source)
+      
+    case ._handleSaveTodayShortsResponse(.success):
+      return Effect(value: ._presentSuccessToast("오늘 읽을 숏스에 저장됐어요:)"))
+      
+    case ._handleSaveTodayShortsResponse(.failure):
+      return Effect(value: ._presentFailureToast("인터넷이 불안정해서 저장되지 못했어요."))
       
     case let ._sortNewsItems(sortType):
       var sortedNewsItems = state.newsItems

--- a/Projects/Features/Scene/NewsCardScene/NewsList/NewsListView.swift
+++ b/Projects/Features/Scene/NewsCardScene/NewsList/NewsListView.swift
@@ -74,8 +74,8 @@ public struct NewsListView: View {
         VStack(spacing: 0) {
           Spacer()
           
-          BottomButton(title: "다 읽었어요") {
-            viewStore.send(.completeButtonTapped)
+          BottomButton(title: viewStore.source == .shortStorage ? "다 읽었어요" : "오늘 읽을 숏스에 저장") {
+            viewStore.send(viewStore.source == .shortStorage ? .completeButtonTapped : .saveButtonTapped)
           }
         }
       }
@@ -103,6 +103,22 @@ public struct NewsListView: View {
           )
         }
       )
+      .apply(content: { view in
+        WithViewStore(store.scope(state: \.successToastMessage)) { successToastMessageViewStore in
+          view.toast(
+            text: successToastMessageViewStore.state,
+            toastType: .info
+          )
+        }
+      })
+      .apply(content: { view in
+        WithViewStore(store.scope(state: \.failureToastMessage)) { failureToastMessageViewStore in
+          view.toast(
+            text: failureToastMessageViewStore.state,
+            toastType: .warning
+          )
+        }
+      })
     }
   }
 }


### PR DESCRIPTION
## Task

- 메인, 핫키워드에서 진입하는 뉴스 리스트의 바텀 버튼 동작 수정

## 참고

- 메인, 핫 키워드에서 진입 시 뉴스 리스트의 바텀 버튼 > 오늘 읽을 쇼스에 저장
- 숏스토리지에서 진입 시 뉴스 리스트의 바텀 버튼 > 다 읽었어요 버튼
- 롱스토리지의 경우 별도의 뷰를 사용중이므로 별도 처리 필요 x
