### PR TITLE
버그: 오래 간직할 숏스 카테고리 필터링 버그 수정

### DIFF
--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageNewsListCore.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageNewsListCore.swift
@@ -197,7 +197,7 @@ public let longStorageNewsListReducer = Reducer<
       
     case ._filterLongShortsItems:
       var filteredShortsNewsItems = state.allShortsNewsItems.filter {
-        if let category = CategoryType(rawValue: $0.cardState.news.type) {
+        if let category = CategoryType(uppercasedName: $0.cardState.news.category) {
           return state.selectedCategories.contains(category)
         }
         return false
@@ -294,6 +294,7 @@ public let longStorageNewsListReducer = Reducer<
           )
         )
       })
+      state.allShortsNewsItems = state.shortsNewsItems
       return .none
       
     case ._setLongShortsItemList:


### PR DESCRIPTION
## Task
- close #136 

## 참고
전체 오래 간직할 숏스를 가지고 있는 상태에서 필터링 진행했습니다.

## 스크린샷
![Simulator Screen Recording - iPhone 13 mini - 2023-07-07 at 10 24 00](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/48887389/7ca713de-c6ff-4e18-82aa-d529eb8bf716)
