### PR TITLE
수정: 서버 URI 변경 대응

### DIFF
--- a/Projects/Core/Models/Network/NewsCard/RequestDTO/HotKeywordNewsCardRequestDTO.swift
+++ b/Projects/Core/Models/Network/NewsCard/RequestDTO/HotKeywordNewsCardRequestDTO.swift
@@ -1,0 +1,28 @@
+//
+//  HotKeywordNewsCardRequestDTO.swift
+//  Models
+//
+//  Created by 안상희 on 2023/07/08.
+//  Copyright © 2023 mashup.seeYouAgain. All rights reserved.
+//
+
+import Foundation
+
+public struct HotKeywordNewsCardRequestDTO: Encodable {
+  let keyword: String
+  let targetDateTime: String
+  let cursorId: Int
+  let size: Int
+  
+  public init(
+    keyword: String,
+    targetDateTime: String,
+    cursorId: Int,
+    size: Int
+  ) {
+    self.keyword = keyword
+    self.targetDateTime = targetDateTime
+    self.cursorId = cursorId
+    self.size = size
+  }
+}

--- a/Projects/Core/Services/MyPage/MyPageAPI.swift
+++ b/Projects/Core/Services/MyPage/MyPageAPI.swift
@@ -29,7 +29,7 @@ extension MyPageAPI: TargetType {
       return "/member/info"
       
     case .getTodayShorts:
-      return "/member-news-card/"
+      return "/member-news-card/saved"
       
     case .deleteTodayShorts:
       return "/member-news-card"

--- a/Projects/Core/Services/NewsCard/NewsCardAPI.swift
+++ b/Projects/Core/Services/NewsCard/NewsCardAPI.swift
@@ -39,8 +39,8 @@ extension NewsCardAPI: TargetType {
     case .completeTodayShorts:
       return "/member-news-card"
       
-    case let .hotkeywordFetchNews(keyword, _, _, _):
-      return "/hot-keywords/\(keyword)"
+    case .hotkeywordFetchNews:
+      return "/news"
       
     case .saveNews:
       return "/member/news"
@@ -102,8 +102,9 @@ extension NewsCardAPI: TargetType {
       let requestDTO = CompleteTodayShortsRequestDTO(newsCardId: shortsId)
       return .requestJSONEncodable(requestDTO)
       
-    case let .hotkeywordFetchNews(_, targetDateTime, cursorId, pagingSize):
-      let requestDTO = NewsCardsRequestDTO(
+    case let .hotkeywordFetchNews(keyword, targetDateTime, cursorId, pagingSize):
+      let requestDTO = HotKeywordNewsCardRequestDTO(
+        keyword: keyword,
         targetDateTime: targetDateTime.toFormattedString(format: "yyyy-MM-dd'T'HH:mm:ss"),
         cursorId: cursorId,
         size: pagingSize

--- a/Projects/Core/Services/NewsCard/NewsCardAPI.swift
+++ b/Projects/Core/Services/NewsCard/NewsCardAPI.swift
@@ -15,7 +15,7 @@ public enum NewsCardAPI {
   case saveNewsCard(Int)
   case getNewsCard(Int)
   case completeTodayShorts(Int)
-  case fetchNews(String, Date, Int, Int)
+  case hotkeywordFetchNews(String, Date, Int, Int)
   case saveNews(Int)
   case checkSavedStatus(Int)
 }
@@ -39,7 +39,7 @@ extension NewsCardAPI: TargetType {
     case .completeTodayShorts:
       return "/member-news-card"
       
-    case let .fetchNews(keyword, _, _, _):
+    case let .hotkeywordFetchNews(keyword, _, _, _):
       return "/hot-keywords/\(keyword)"
       
     case .saveNews:
@@ -64,7 +64,7 @@ extension NewsCardAPI: TargetType {
     case .completeTodayShorts:
       return .delete
       
-    case .fetchNews:
+    case .hotkeywordFetchNews:
       return .get
       
     case .saveNews:
@@ -102,7 +102,7 @@ extension NewsCardAPI: TargetType {
       let requestDTO = CompleteTodayShortsRequestDTO(newsCardId: shortsId)
       return .requestJSONEncodable(requestDTO)
       
-    case let .fetchNews(_, targetDateTime, cursorId, pagingSize):
+    case let .hotkeywordFetchNews(_, targetDateTime, cursorId, pagingSize):
       let requestDTO = NewsCardsRequestDTO(
         targetDateTime: targetDateTime.toFormattedString(format: "yyyy-MM-dd'T'HH:mm:ss"),
         cursorId: cursorId,

--- a/Projects/Core/Services/NewsCard/NewsCardService.swift
+++ b/Projects/Core/Services/NewsCard/NewsCardService.swift
@@ -84,7 +84,7 @@ extension NewsCardService {
       return Provider<NewsCardAPI>
         .init()
         .request(
-          NewsCardAPI.fetchNews(keyword, targetDateTime, cursorId, pagingSize),
+          NewsCardAPI.hotkeywordFetchNews(keyword, targetDateTime, cursorId, pagingSize),
           type: [NewsResponseDTO].self
         )
         .compactMap { $0 }


### PR DESCRIPTION
## Task

- 핫 키워드로 뉴스 조회 URI 변경
   - 기존 : /v1/hot-keywords/{keyword}
   - 변경 : /v1/news?keyword={} ...

- 저장한 오늘의 숏스 조회 URI 변경
   - 기존 : /v1/member-news-card/
   - 변경 : /v1/member-news-card/save


