### PR TITLE
버그: 1차 QA 이슈 해결

### DIFF
--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/DateFilterBottomSheet/DateFilterBottomSheetCore.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/DateFilterBottomSheet/DateFilterBottomSheetCore.swift
@@ -11,15 +11,25 @@ import ComposableArchitecture
 import Foundation
 
 struct DateFilterBottomSheetState: Equatable {
-  public var year: Int = Date().yearToInt()
-  public var month: Int = Date().monthToInt() - 1 // 피커에서 배열 인덱스로 사용해서 1을 빼줌
+  public var year: Int
+  public var month: Int // 피커에서 배열 인덱스로 사용해서 1을 빼줌
   public var isPresented: Bool
   
-  public var years: [Int] = [2023]
-  public var months = [Int](1...Date().monthToInt())
+  public var years: [Int]
+  public var months: [Int]
   
-  init(isPresented: Bool = false) {
+  init(
+    year: Int = Date().yearToInt(),
+    month: Int = Date().monthToInt() - 1,
+    isPresented: Bool = false,
+    years: [Int] = [2023],
+    months: [Int] = Array(1...Date().monthToInt())
+  ) {
+    self.year = year
+    self.month = month
     self.isPresented = isPresented
+    self.years = years
+    self.months = months
   }
 }
 

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageNewsListCore.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageNewsListCore.swift
@@ -224,7 +224,10 @@ public let longStorageNewsListReducer = Reducer<
       .eraseToEffect()
       
     case let ._handleFetchSavedNewsResponse(savedNewsList, fetchType):
-      return handleSavedNewsResponse(&state, source: savedNewsList, fetchType: fetchType)
+      return .concatenate([
+        handleSavedNewsResponse(&state, source: savedNewsList, fetchType: fetchType),
+        Effect(value: ._sortLongShortsItems(state.sortType)),
+      ])
       
     case let ._deleteSavedNews(newsIds):
       return env.myPageService.deleteNews(newsIds)

--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageNewsListCore.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongStorageNewsListCore.swift
@@ -176,7 +176,10 @@ public let longStorageNewsListReducer = Reducer<
       return Effect(value: .categoryFilterBottomSheet(._setIsPresented(true)))
       
     case .showDateFilterBottomSheet:
-      state.dateFilterBottomSheetState = .init()
+      state.dateFilterBottomSheetState = .init(
+        year: state.dateType.year,
+        month: state.dateType.month - 1
+      )
       return Effect(value: .dateFilterBottomSheet(._setIsPresented(true)))
       
     case ._viewWillAppear:

--- a/Projects/Features/Scene/NewsCardScene/NewsList/NewsListCore.swift
+++ b/Projects/Features/Scene/NewsCardScene/NewsList/NewsListCore.swift
@@ -153,7 +153,10 @@ public let newsListReducer = Reducer.combine([
         .catchToEffect(NewsListAction._handleSaveTodayShortsResponse)
       
     case let ._handleNewsResponse(source):
-      return handleSourceType(&state, env, source: source)
+      return .concatenate([
+        handleSourceType(&state, env, source: source),
+        Effect(value: ._sortNewsItems(state.sortType)),
+      ])
       
     case ._handleSaveTodayShortsResponse(.success):
       return Effect(value: ._presentSuccessToast("오늘 읽을 숏스에 저장됐어요:)"))

--- a/Projects/Features/Scene/TabBarScene/TabBar/TabBarCore.swift
+++ b/Projects/Features/Scene/TabBarScene/TabBar/TabBarCore.swift
@@ -216,6 +216,19 @@ public let tabBarReducer = Reducer<
     case .myPage(
       .routeAction(
         _,
+        action: .longStorage(
+          .routeAction(
+            _,
+            action: .longStorageNewsList(._viewWillAppear)
+          )
+        )
+      )
+    ):
+      return Effect(value: ._setTabHiddenStatus(true))
+      
+    case .myPage(
+      .routeAction(
+        _,
         action: .shortStorage(
           .routeAction(
             _,


### PR DESCRIPTION
## Task
#152 
#151 
#154 

## 작업내용
1차 QA에서 발견된 이슈 중 현재 이슈에 등록된 이슈 처리했습니다.
1. 필터링 유지되지 않는 이슈 해결
2. 오래 간직할 숏스의 날짜 선택 피커 노출 시 현재 월로 노출되지 않고 최신 월로 고정되는것 해결
3. 오래 간직할 숏스 > 웹뷰에서 다시 복귀 시 탭바 노출 되는 현상 해결
4. 기타 탭바가 나타나지 않아야할 곳들에서 나타나는지와 나타나야되는데 나타나지 않는지에 대한 전체 테스트 및 점검 했습니다.

아래는 필터링 이슈 해결되어 이상없는 gif 입니다.
![1](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/72292617/dc7e6d34-3774-4b93-97d5-6c3585860287)



