### PR TITLE
수정: 핫키워드로 뉴스 리스트 접근 시 하단 버튼 미노출

### DIFF
--- a/Projects/Features/Scene/NewsCardScene/NewsList/NewsListView.swift
+++ b/Projects/Features/Scene/NewsCardScene/NewsList/NewsListView.swift
@@ -65,17 +65,19 @@ public struct NewsListView: View {
               .padding(.bottom, 16)
             }
           }
-          .padding(.bottom, 48)
+          .padding(.bottom, viewStore.state.source != .hot ? 48 : 0)
         }
         .onAppear {
           viewStore.send(._onAppear)
         }
         
-        VStack(spacing: 0) {
-          Spacer()
-          
-          BottomButton(title: viewStore.source == .shortStorage ? "다 읽었어요" : "오늘 읽을 숏스에 저장") {
-            viewStore.send(viewStore.source == .shortStorage ? .completeButtonTapped : .saveButtonTapped)
+        if viewStore.state.source != .hot {
+          VStack(spacing: 0) {
+            Spacer()
+            
+            BottomButton(title: viewStore.source == .shortStorage ? "다 읽었어요" : "오늘 읽을 숏스에 저장") {
+              viewStore.send(viewStore.source == .shortStorage ? .completeButtonTapped : .saveButtonTapped)
+            }
           }
         }
       }


### PR DESCRIPTION
## Task

[핫 키워드로 뉴스 리스트 접근 시 하단 버튼 미노출]()

## 참고

https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/72292617/e41a30d6-7c03-4cca-b433-0211dd27746c



