### PR TITLE
기능: hot keyword 화면, background에서 foreground 됐을 때 refresh

### DIFF
--- a/Projects/Features/Scene/HotKeywordScene/HotKeyword/HotKeywordCore.swift
+++ b/Projects/Features/Scene/HotKeywordScene/HotKeyword/HotKeywordCore.swift
@@ -27,6 +27,7 @@ public struct HotKeywordState: Equatable {
 
 public enum HotKeywordAction: Equatable {
   // MARK: - User Action
+  case backToForeground
   case pullToRefresh
   case hotKeywordCircleTapped(String, currentOffset: CGFloat)
   
@@ -69,6 +70,12 @@ public let hotKeywordReducer = Reducer.combine([
     struct SetHotKeywordToastCancelID: Hashable {}
     
     switch action {
+    case .backToForeground:
+      return .concatenate([
+        Effect(value: ._fetchData),
+        Effect(value: ._setIsRefresh(true))
+      ])
+      
     case .pullToRefresh:
       return .concatenate([
         Effect(value: ._fetchData),

--- a/Projects/Features/Scene/HotKeywordScene/HotKeyword/HotKeywordView.swift
+++ b/Projects/Features/Scene/HotKeywordScene/HotKeyword/HotKeywordView.swift
@@ -66,6 +66,9 @@ public struct HotKeywordView: View {
           offset = basicOffset
         }
       }
+      .onAppCameToForeground {
+        viewStore.send(.backToForeground)
+      }
     }
     .navigationBarHidden(true)
     .apply(content: { view in
@@ -178,6 +181,14 @@ extension HotKeywordView {
     static var defaultValue: CGFloat = .zero
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
       value += nextValue()
+    }
+  }
+}
+
+fileprivate extension View {
+  func onAppCameToForeground(perform action: @escaping () -> Void) -> some View {
+    self.onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+      action()
     }
   }
 }


### PR DESCRIPTION
## Task
#164 

## 참고
간헐적으로 핫 키워드 사라지는 현상은 따로 이슈로 진행할 예정입니다.

## 영상
https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/49546979/859640ee-d98b-4a21-8de8-a730fb5bd363

