### PR TITLE
버그: 메인에서 뉴스카드 접근 시 로딩 인디케이터 처리

### DIFF
--- a/Projects/Features/Scene/NewsCardScene/NewsList/NewsListCore.swift
+++ b/Projects/Features/Scene/NewsCardScene/NewsList/NewsListCore.swift
@@ -299,7 +299,10 @@ private func handleSourceType(
         switch result {
         case let .success(news):
           let news = news.map { $0.toDomain }
-          return Effect(value: ._setNewsItems(news))
+          return Effect.concatenate([
+            Effect(value: ._setIsLoading(false)),
+            Effect(value: ._setNewsItems(news))
+          ])
         case .failure:
           return .none
         }


### PR DESCRIPTION
## Task
- close #173 

## 참고
- `setIsLoading(false)` 추가했습니다.

## 스크린 샷
![Simulator Screen Recording - iPhone 13 mini - 2023-07-17 at 01 32 16](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/48887389/ad4b7246-e3f1-4f20-bc9b-44015353c579)
