### PR TITLE
버그: 오늘의 숏스를 다 읽었을 때 보여주는 뷰의  처리 수정

### DIFF
--- a/Projects/Features/Scene/ShortStorageScene/ShortStorageNewsList/ShortStorageNewsListView.swift
+++ b/Projects/Features/Scene/ShortStorageScene/ShortStorageNewsList/ShortStorageNewsListView.swift
@@ -43,19 +43,14 @@ public struct ShortStorageNewsListView: View {
               shortsCompleteCount: viewStore.shortsCompleteCount
             )
             
+            // 현재 저장한 오늘의 숏스가 없는 경우
             if viewStore.shortsNewsItemsCount == 0 {
-              // 오늘 저장한 숏스 없는 경우
               EmptyNewsContentView(
                 shortsNewsItemsCount: viewStore.shortsNewsItemsCount,
                 shortsCompleteCount: viewStore.shortsCompleteCount,
-                message: "오늘은 아직 저장한 뉴스가 없어요\n뉴스를 보고 마음에 드면 저장해보세요"
-              )
-            } else if viewStore.shortsCompleteCount != 0 && viewStore.shortsNewsItemsCount == 0 {
-              // 오늘 저장한 숏스 다 읽은 경우
-              EmptyNewsContentView(
-                shortsNewsItemsCount: viewStore.shortsNewsItemsCount,
-                shortsCompleteCount: viewStore.shortsCompleteCount,
-                message: "오늘 저장한 뉴스를 다 읽었어요!"
+                message: viewStore.shortsCompleteCount == 0 ?
+                "오늘은 아직 저장한 뉴스가 없어요\n뉴스를 보고 마음에 드면 저장해보세요" :
+                  "오늘 저장한 뉴스를 다 읽었어요!"
               )
             } else {
               Spacer()


### PR DESCRIPTION
## Task
- close #171 

## 참고
- 오늘의 숏스를 다 읽었을 때는 다른 문구를 보여줘야하는데 잘못 보여주고 있는 상태여서 수정했습니다.~!

## 스크린 샷
![Simulator Screen Recording - iPhone 14 Pro Max - 2023-07-17 at 01 53 55](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/48887389/13069c16-1569-4cb8-ba9d-06138e8dc669)
