### PR TITLE
수정: 핫 키워드 간헐적으로 애니메이션 동작하지 않는 현상 수정 및 탭 눌렀을때 동작 추가

### DIFF
--- a/Projects/DesignSystem/Sources/Views/Bubble/BubbleView.swift
+++ b/Projects/DesignSystem/Sources/Views/Bubble/BubbleView.swift
@@ -22,7 +22,7 @@ public struct BubbleView: View {
   // 써클의 중앙이 보일때 애니메이션을 시작해야하는데, 스크롤 할 때 offset이 크게 잡히는 경향이 있어서 여유 공간을 뺀 너비를 사용함
   private let spaceWidth: CGFloat = {
     let screenWidth = UIScreen.main.bounds.width
-    return screenWidth - screenWidth / 4
+    return screenWidth * 2 / 3
   }()
   
   public init(
@@ -63,6 +63,8 @@ public struct BubbleView: View {
         .onChange(of: offset) { currentOffset in
           if isAnimated == false {
             isAnimated = currentOffset > (pointX - spaceWidth)
+          } else if currentOffset < (pointX - spaceWidth * 3 / 2) {
+            isAnimated = false
           }
         }
         .frame(

--- a/Projects/Features/Scene/HotKeywordScene/HotKeyword/HotKeywordCore.swift
+++ b/Projects/Features/Scene/HotKeywordScene/HotKeyword/HotKeywordCore.swift
@@ -33,8 +33,8 @@ public enum HotKeywordAction: Equatable {
   case backToForeground
   case pullToRefresh
   case hotKeywordCircleTapped(String, currentOffset: CGFloat)
-  case hotkeywordTapTapped
-  case otherTapsTapped
+  case hotkeywordTabTapped
+  case otherTabsTapped
   
   // MARK: - Inner Business Action
   case _fetchData
@@ -99,14 +99,14 @@ public let hotKeywordReducer = Reducer.combine([
         Effect(value: ._setCurrentOffset(offset))
       ])
       
-    case .hotkeywordTapTapped:
+    case .hotkeywordTabTapped:
       return .concatenate([
         Effect(value: ._setIsFirstLoading(false)),
         Effect(value: ._setIsScrollToLeading(true)),
         Effect(value: ._setHotkeywordVisiable(true))
       ])
       
-    case .otherTapsTapped:
+    case .otherTabsTapped:
       return Effect(value: ._setHotkeywordVisiable(false))
       
     case ._fetchData:

--- a/Projects/Features/Scene/TabBarScene/TabBar/TabBarCore.swift
+++ b/Projects/Features/Scene/TabBarScene/TabBar/TabBarCore.swift
@@ -147,14 +147,14 @@ public let tabBarReducer = Reducer<
     case let .tabSelected(tab):
       state.selectedTab = tab
       if tab == .hotKeyword {
-        return Effect(value: .hotKeyword(.routeAction(0, action: .hotKeyword(.hotkeywordTapTapped))))
+        return Effect(value: .hotKeyword(.routeAction(0, action: .hotKeyword(.hotkeywordTabTapped))))
       } else if tab == .myPage {
         return .concatenate(
           Effect(value: .myPage(.routeAction(0, action: .myPage(._viewWillAppear)))),
-          Effect(value: .hotKeyword(.routeAction(0, action: .hotKeyword(.otherTapsTapped))))
+          Effect(value: .hotKeyword(.routeAction(0, action: .hotKeyword(.otherTabsTapped))))
         )
       } else {
-        return Effect(value: .hotKeyword(.routeAction(0, action: .hotKeyword(.otherTapsTapped))))
+        return Effect(value: .hotKeyword(.routeAction(0, action: .hotKeyword(.otherTabsTapped))))
       }
       
     case let ._presentInfoToast(toastMessage):

--- a/Projects/Features/Scene/TabBarScene/TabBar/TabBarCore.swift
+++ b/Projects/Features/Scene/TabBarScene/TabBar/TabBarCore.swift
@@ -147,11 +147,15 @@ public let tabBarReducer = Reducer<
     case let .tabSelected(tab):
       state.selectedTab = tab
       if tab == .hotKeyword {
-        return Effect(value: .hotKeyword(.routeAction(0, action: .hotKeyword(._viewWillAppear))))
+        return Effect(value: .hotKeyword(.routeAction(0, action: .hotKeyword(.hotkeywordTapTapped))))
       } else if tab == .myPage {
-        return Effect(value: .myPage(.routeAction(0, action: .myPage(._viewWillAppear))))
+        return .concatenate(
+          Effect(value: .myPage(.routeAction(0, action: .myPage(._viewWillAppear)))),
+          Effect(value: .hotKeyword(.routeAction(0, action: .hotKeyword(.otherTapsTapped))))
+        )
+      } else {
+        return Effect(value: .hotKeyword(.routeAction(0, action: .hotKeyword(.otherTapsTapped))))
       }
-      return .none
       
     case let ._presentInfoToast(toastMessage):
       return .concatenate(


### PR DESCRIPTION
## Task
#169 

## 버그 수정
- 핫 키워드 탭 진입 전 핫 키워드 화면이 onDisappear 되는 상황(메인에서 뉴스 리스트를 보며 화면 덮일 때 등)에서 offset을 0으로 설정되어버림
- 0인 경우 basic offset을 가져가서 보일 수 있도록 변경
- todo로 남아있던 부분 수정(코드 정리, 리프레시때 유저 인터렉션 막기, 데이터 로딩 안됐을때 subtitle 설정)

## 참고
- 핫 키워드 내에서 탭 다시 눌렀을 때, 스크롤 리딩으로 향하도록 변경
- 스크롤 리딩으로 했을때, (보이진 않지만) 핫 키워드 원 작아지도록 수정 -> 다시 스크롤 했을때 커지는 애니메이션 볼 수 있음