### PR TITLE
기능: 뉴스 카드 썸네일 이미지 로드 완료 전 스켈레톤 이미지 구현

### DIFF
--- a/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongShortsItem/LongShortsCardView.swift
+++ b/Projects/Features/Scene/LongStorageScene/LongStorageNewsList/LongShortsItem/LongShortsCardView.swift
@@ -30,6 +30,10 @@ struct LongShortsCardView: View {
                 .resizable()
                 .frame(width: 56, height: 56)
                 .clipShape(Circle())
+            } else {
+              DesignSystem.Colors.grey30
+                .frame(width: 56, height: 56)
+                .clipShape(Circle())
             }
           }
           

--- a/Projects/Features/Scene/NewsCardScene/NewsList/NewsCard/NewsCardView.swift
+++ b/Projects/Features/Scene/NewsCardScene/NewsList/NewsCard/NewsCardView.swift
@@ -30,6 +30,10 @@ public struct NewsCardView: View {
                 .resizable()
                 .frame(width: 56, height: 56)
                 .clipShape(Circle())
+            } else {
+              DesignSystem.Colors.grey30
+                .frame(width: 56, height: 56)
+                .clipShape(Circle())
             }
           }
 


### PR DESCRIPTION
## Task

[close #172]()

## 참고
이미지 로드 완료 전 화면입니다!
![CleanShot 2023-07-20 at 12 33 41@2x](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/95578975/24fb8ea0-ae24-4958-9238-c079a1a3e939)