### PR TITLE
수정: 홈 키워드 좌측 그라데이션 뷰 색상 변경

### DIFF
--- a/Projects/Features/Scene/MainScene/Main/Category/CategoriesView.swift
+++ b/Projects/Features/Scene/MainScene/Main/Category/CategoriesView.swift
@@ -53,8 +53,8 @@ private struct GradientView: View {
     HStack {
       LinearGradient(
         colors: [
-          DesignSystem.Colors.lightBlue,
-          DesignSystem.Colors.lightBlue.opacity(0)
+          Color(red: 0.84, green: 0.91, blue: 0.97),
+          Color(red: 0.87, green: 0.92, blue: 0.95).opacity(0)
         ],
         startPoint: .leading,
         endPoint: .trailing


### PR DESCRIPTION
## Task

[홈 키워드 좌측 그라데이션 뷰 색상 변경]()

## 참고
- 원인은 시작/종료 위치가 상이했던것이 아닌 기존 뒷 배경에 깔린 그라데이션 뷰의 색상과 동일하지 않기에 발생 
- 백그라운드로 깔린 그라데이션이 이미 블러 처리가 되어 있어서 완벽하게 그라데이션에서 location을 일일히 수치별로 잡기는 무리가 있음
  - 기기별로 백그라운드 원의 사이즈 등 다 다르기 때문에
- 위와 같은 이유로 피그마에 해당 그라데이션 색상과 동일하게 수정했으며 이전보다는 확실히 어색하진 않으나 아주 자세히 보면 조금 색상이 다른 부분이 보이긴함
- 일일히 수치별로 잡는것은 공수가 많이 들고 크게 유의미한 작업은 아닐것 같아 우선 어색하지 않도록 처리함
![Simulator Screenshot - iPhone 14 Pro - 2023-07-22 at 06 28 00](https://github.com/mash-up-kr/SeeYouAgain_iOS/assets/72292617/fbb574f4-7136-4454-badb-5281b544252a)


